### PR TITLE
Build container images to ghcr.io

### DIFF
--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -4,7 +4,7 @@ env:
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: blender_env
   TEST_TAG: blender_env:tests
-  LATEST_VERSION: "3.1"
+  LATEST_VERSION: '3.1'
   
 
 on:
@@ -13,8 +13,8 @@ on:
       - main
       - workflow
     paths:
-      - "Dockerfiles/Dockerfile.base_*"
-      - ".github/workflows/build_blend_env_image.yml"
+      - 'Dockerfiles/Dockerfile.base**'
+      - '.github/workflows/build_blender_env_image.yml'
   workflow_dispatch:
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ["3.0", "3.1"]
+        blender-version: ['3.0', '3.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -63,6 +63,12 @@ jobs:
           # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
 #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
 #           cache-to: type=inline
+      - name: Tag latest image GHCR
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
+        if: ${{ matrix.blender-version == env.LATEST_VERSION }}
       # Keep the dockerhub images just for backward compatibility check
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -74,3 +80,4 @@ jobs:
         with:
           src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -2,8 +2,8 @@ name: Build blend_env image
 
 env:
   DOCKERHUB_USERNAME: luciusm
-  IMAGE_NAME: blender_env
-  TEST_TAG: blender_env:tests
+  IMAGE_NAME: blender-env
+  TEST_TAG: blender-env:tests
   LATEST_VERSION: "3.1"
 
 on:
@@ -43,11 +43,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set lower case repository name
-        # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
+        # Hit from https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
         run: |
           echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
         env:
           OWNER: "${{ github.repository_owner }}"
+      - name: Name conversion between ghcr & dockerhub. Replace - with _
+        run: |
+          echo "DOCKERHUB_IMAGE_NAME=${IMG/-/_}" >> ${GITHUB_ENV}
+        env:
+          IMG: "${{ env.IMAGE_NAME }}"
       - name: Build and push to GHCR
         uses: docker/build-push-action@v2
         with:
@@ -65,7 +70,7 @@ jobs:
           src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}
-      # Keep the dockerhub images just for backward compatibility check
+      # Keep the dockerhub images just for backward compatibility check. Ok to fail
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -75,4 +80,4 @@ jobs:
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -4,8 +4,7 @@ env:
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: blender_env
   TEST_TAG: blender_env:tests
-  LATEST_VERSION: '3.1'
-  
+  LATEST_VERSION: "3.1"
 
 on:
   push:
@@ -13,8 +12,8 @@ on:
       - main
       - workflow
     paths:
-      - 'Dockerfiles/Dockerfile.base**'
-      - '.github/workflows/build_blender_env_image.yml'
+      - "Dockerfiles/Dockerfile.base**"
+      - ".github/workflows/build_blender_env_image.yml"
   workflow_dispatch:
 
 jobs:
@@ -23,7 +22,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ['3.0', '3.1']
+        blender-version: ["3.0", "3.1"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -48,7 +47,7 @@ jobs:
         run: |
           echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
         env:
-          OWNER: '${{ github.repository_owner }}'
+          OWNER: "${{ github.repository_owner }}"
       - name: Build and push to GHCR
         uses: docker/build-push-action@v2
         with:
@@ -58,11 +57,8 @@ jobs:
           build-args: BLENDER_VERSION=${{ matrix.blender-version }}
           tags: |
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
-          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
-#           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
-#           cache-to: type=inline
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Tag latest image GHCR
         uses: akhilerm/tag-push-action@v2.0.0
         with:
@@ -80,4 +76,3 @@ jobs:
         with:
           src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-      

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -1,10 +1,17 @@
 name: Build blend_env image
 
 env:
-  image_name: blender_env
+  DOCKERHUB_USERNAME: luciusm
+  IMAGE_NAME: blender_env
+  TEST_TAG: blender_env:tests
+  LATEST_VERSION: "3.1"
+  
 
 on:
   push:
+    branches:
+      - main
+      - workflow
     paths:
       - "Dockerfiles/Dockerfile.base_*"
       - ".github/workflows/build_blend_env_image.yml"
@@ -30,20 +37,34 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           endpoint: builders
-      - name: Login to DockerHub
+      - name: Login to Github Container Repo
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set lower case repository name
+        # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
+        run: |
+          echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
+      - name: Build and push to GHCR
         uses: docker/build-push-action@v2
         with:
           context: ./
           file: ./Dockerfiles/Dockerfile.base_3.x
           push: true
           build-args: BLENDER_VERSION=${{ matrix.blender-version }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
+          tags: |
+            ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          # tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
+          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
+          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
 #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
 #           cache-to: type=inline

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -43,11 +43,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set lower case repository name
         # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
         run: |
@@ -63,8 +58,19 @@ jobs:
           build-args: BLENDER_VERSION=${{ matrix.blender-version }}
           tags: |
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          # tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
-          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
+          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
           # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
 #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
 #           cache-to: type=inline
+      # Keep the dockerhub images just for backward compatibility check
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Copy images between GHCR and Dockerhub
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -67,6 +67,8 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
       - name: Tag latest image 
         uses: akhilerm/tag-push-action@v2.0.0
         with:

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -4,7 +4,7 @@ env:
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
-  LATEST_VERSION: '3.1'
+  LATEST_VERSION: "3.1"
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ['3.0', '3.1']
+        blender-version: ["3.0", "3.1"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +57,7 @@ jobs:
         run: |
           echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
         env:
-          OWNER: '${{ github.repository_owner }}'
+          OWNER: "${{ github.repository_owner }}"
       - name: Push image to Dockerhub & GHCR
         uses: docker/build-push-action@v2
         with:
@@ -67,9 +67,9 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          cache-from: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
-          cache-to: type=registry,ref=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:buildcache
-      - name: Tag latest image 
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Tag latest image
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
@@ -86,7 +86,7 @@ jobs:
       #     tags: |
       #       docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
       #       ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-      # - name: Tag latest image 
+      # - name: Tag latest image
       #   uses: akhilerm/tag-push-action@v2.0.0
       #   with:
       #     src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -44,11 +44,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build local copy
         uses: docker/build-push-action@v2
         with:
@@ -71,13 +71,29 @@ jobs:
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           push: true
           tags: |
-            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
       - name: Tag latest image 
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: |
-            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}
+      # - name: Push image to Dockerhub & GHCR
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: ./
+      #     file: ./Dockerfiles/Dockerfile.main
+      #     build-args: BLENDER_VER=${{ matrix.blender-version }}
+      #     push: true
+      #     tags: |
+      #       docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      #       ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      # - name: Tag latest image 
+      #   uses: akhilerm/tag-push-action@v2.0.0
+      #   with:
+      #     src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      #     dst: |
+      #       docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+      #       ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
+      #   if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -2,8 +2,8 @@ name: Build beautiful_atoms main image
 
 env:
   DOCKERHUB_USERNAME: luciusm
-  IMAGE_NAME: beautiful_atoms
-  TEST_TAG: beautiful_atoms:tests
+  IMAGE_NAME: beautiful-atoms
+  TEST_TAG: beautiful-atoms:tests
   LATEST_VERSION: "3.1"
 
 on:
@@ -39,25 +39,17 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      # - name: Build local copy
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: ./
-      #     file: ./Dockerfiles/Dockerfile.main
-      #     build-args: BLENDER_VER=${{ matrix.blender-version }}
-      #     load: true
-      #     tags: ${{ env.TEST_TAG }}
       - name: Set lower case repository name
-        # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
+        # Hint from https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
         run: |
           echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
         env:
           OWNER: "${{ github.repository_owner }}"
+      - name: Name conversion between ghcr & dockerhub. Replace - with _
+        run: |
+          echo "DOCKERHUB_IMAGE_NAME=${IMG/-/_}" >> ${GITHUB_ENV}
+        env:
+          IMG: "${{ env.IMAGE_NAME }}"
       - name: Push image to Dockerhub & GHCR
         uses: docker/build-push-action@v2
         with:
@@ -72,25 +64,22 @@ jobs:
       - name: Tag latest image
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          dst: |
-            ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
+          src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}
-      # - name: Push image to Dockerhub & GHCR
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: ./
-      #     file: ./Dockerfiles/Dockerfile.main
-      #     build-args: BLENDER_VER=${{ matrix.blender-version }}
-      #     push: true
-      #     tags: |
-      #       docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-      #       ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-      # - name: Tag latest image
-      #   uses: akhilerm/tag-push-action@v2.0.0
-      #   with:
-      #     src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-      #     dst: |
-      #       docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-      #       ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
-      #   if: ${{ matrix.blender-version == env.LATEST_VERSION }}
+      # Tagging from ghcr --> dockerhub is optional and ok to fail
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Copy images between GHCR and Dockerhub
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      - name: Tag latest image dockerhub
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -67,12 +67,12 @@ jobs:
           tags: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
             # ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-            ghcr.io/${{ github.event.repository_owner }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
       - name: Tag latest image 
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ github.event.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -74,4 +74,4 @@ jobs:
           tags: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:latest
-          if: matrix.os == env.LATEST_VERSION
+          if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -71,7 +71,7 @@ jobs:
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-          tags: |
+          dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
             ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:latest
-          if: ${{ matrix.blender-version == env.LATEST_VERSION }}
+        if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -2,6 +2,7 @@ name: Build beautiful_atoms main image
 
 env:
   DOCKERHUB_USERNAME: luciusm
+  BASE_IMAGE_NAME: blender-env
   IMAGE_NAME: beautiful-atoms
   TEST_TAG: beautiful-atoms:tests
   LATEST_VERSION: "3.1"
@@ -51,11 +52,13 @@ jobs:
         env:
           IMG: "${{ env.IMAGE_NAME }}"
       - name: Push image to Dockerhub & GHCR
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ./
           file: ./Dockerfiles/Dockerfile.main
-          build-args: BLENDER_VER=${{ matrix.blender-version }}
+          build-args: |
+            BLENDER_VER=${{ matrix.blender-version }}
+            BASE_IMAGE_NAME=ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.BASE_IMAGE_NAME }}
           push: true
           tags: |
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -1,7 +1,7 @@
 name: Build beautiful_atoms main image
 
 env:
-  user_name: alchem0x2a
+  # user_name: alchem0x2a
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
@@ -66,12 +66,13 @@ jobs:
           push: true
           tags: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-            ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+            # ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+            ghcr.io/${{ github.event.repository_owner }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
       - name: Tag latest image 
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ github.event.repository_owner }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -3,6 +3,7 @@ name: Build beautiful_atoms main image
 env:
   image_name: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
+  REGISTRY: ghcr.io
 
 on:
   push:
@@ -38,8 +39,11 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          # username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build local copy
         uses: docker/build-push-action@v2
         with:
@@ -57,6 +61,12 @@ jobs:
       - name: Test local image
         run: |
           docker run --rm -v $(pwd)/tests:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh
+      
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v2
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ env.image_name }}
 
       - name: Push image
         uses: docker/build-push-action@v2
@@ -66,7 +76,7 @@ jobs:
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:latest
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
+            ${{ env.REGISTRY }}/${{ github.repository }}:blender${{ matrix.blender-version }}
+            ${{ env.REGISTRY }}/${{ github.repository }}:latest
+          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
+          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -57,6 +57,12 @@ jobs:
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           load: true
           tags: ${{ env.TEST_TAG }}
+      - name: Set lower case repository name
+        # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
+        run: |
+          echo "REPO_OWNER_LC=${OWNER,,}" >> ${GITHUB_ENV}
+        env:
+          OWNER: '${{ github.repository_owner }}'
       - name: Push image to Dockerhub & GHCR
         uses: docker/build-push-action@v2
         with:
@@ -66,13 +72,12 @@ jobs:
           push: true
           tags: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-            # ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+            ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
       - name: Tag latest image 
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -1,7 +1,6 @@
 name: Build beautiful_atoms main image
 
 env:
-  # user_name: alchem0x2a
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
@@ -11,12 +10,6 @@ on:
   push:
     branches:
       - main
-      - develop
-      - workflow
-  pull_request:
-    branches:
-      - main
-      - develop
       - workflow
   workflow_dispatch:
 

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -1,6 +1,7 @@
 name: Build beautiful_atoms main image
 
 env:
+  user_name: alchem0x2a
   image_name: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
   REGISTRY: ghcr.io
@@ -76,7 +77,7 @@ jobs:
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ github.repository }}:blender${{ matrix.blender-version }}
-            ${{ env.REGISTRY }}/${{ github.repository }}:latest
+            ${{ env.REGISTRY }}/${{ env.user_name }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
+            ${{ env.REGISTRY }}/${{ env.user_name }}/${{ env.image_name }}:latest
           # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
           # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -4,7 +4,7 @@ env:
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
-  LATEST_VERSION: "3.1"
+  LATEST_VERSION: '3.1'
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ["3.0", "3.1"]
+        blender-version: ['3.0', '3.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -2,9 +2,10 @@ name: Build beautiful_atoms main image
 
 env:
   user_name: alchem0x2a
-  image_name: beautiful_atoms
+  DOCKERHUB_USERNAME: luciusm
+  IMAGE_NAME: beautiful_atoms
   TEST_TAG: beautiful_atoms:tests
-  REGISTRY: ghcr.io
+  LATEST_VERSION: "3.1"
 
 on:
   push:
@@ -37,14 +38,17 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           endpoint: builders
-      - name: Login to DockerHub
+      - name: Login to Github Container Repo
         uses: docker/login-action@v1
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          # username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build local copy
         uses: docker/build-push-action@v2
         with:
@@ -52,24 +56,8 @@ jobs:
           file: ./Dockerfiles/Dockerfile.main
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           load: true
-          # push: true
-          # tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
           tags: ${{ env.TEST_TAG }}
-          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
-          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
-      #           cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:${{ matrix.blender-version }}
-      #           cache-to: type=inline
-      - name: Test local image
-        run: |
-          docker run --rm -v $(pwd)/tests:/workdir -e CI=1 ${{ env.TEST_TAG }} bash test_ci.sh
-      
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@v2
-      #   with:
-      #     images: ${{ env.REGISTRY }}/${{ env.image_name }}
-
-      - name: Push image
+      - name: Push image to Dockerhub & GHCR
         uses: docker/build-push-action@v2
         with:
           context: ./
@@ -77,7 +65,13 @@ jobs:
           build-args: BLENDER_VER=${{ matrix.blender-version }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.user_name }}/${{ env.image_name }}:blender${{ matrix.blender-version }}
-            ${{ env.REGISTRY }}/${{ env.user_name }}/${{ env.image_name }}:latest
-          # cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache
-          # cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/${{ env.image_name }}:buildcache,mode=max
+            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+            ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+      - name: Tag latest image 
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          tags: |
+            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:latest
+            ghcr.io/${{ env.user_name }}/${{ env.IMAGE_NAME }}:latest
+          if: matrix.os == env.LATEST_VERSION

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -12,10 +12,12 @@ on:
     branches:
       - main
       - develop
+      - workflow
   pull_request:
     branches:
       - main
       - develop
+      - workflow
   workflow_dispatch:
 
 jobs:
@@ -49,14 +51,14 @@ jobs:
       #   with:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build local copy
-        uses: docker/build-push-action@v2
-        with:
-          context: ./
-          file: ./Dockerfiles/Dockerfile.main
-          build-args: BLENDER_VER=${{ matrix.blender-version }}
-          load: true
-          tags: ${{ env.TEST_TAG }}
+      # - name: Build local copy
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: ./
+      #     file: ./Dockerfiles/Dockerfile.main
+      #     build-args: BLENDER_VER=${{ matrix.blender-version }}
+      #     load: true
+      #     tags: ${{ env.TEST_TAG }}
       - name: Set lower case repository name
         # Hit at https://github.community/t/github-actions-repository-name-must-be-lowercase/184924
         run: |

--- a/Dockerfiles/Dockerfile.base_2.93
+++ b/Dockerfiles/Dockerfile.base_2.93
@@ -2,6 +2,9 @@
 # Dockerfile adapted from https://github.com/nytimes/rd-blender-docker
 # To build the Docker image, create the build from root directory:
 # docker build . -f Dockerfiles/Dockerfile.base_2.93 -t luciusm/blender_env:2.93
+################################################################################
+# This is a deprecated Docker file
+################################################################################
 
 FROM nytimes/blender:2.93-gpu-ubuntu18.04
 

--- a/Dockerfiles/Dockerfile.base_3.x
+++ b/Dockerfiles/Dockerfile.base_3.x
@@ -1,10 +1,17 @@
 # Base image for the blender environment. Used for CD/CI test and debug
 # Dockerfile adapted from https://github.com/nytimes/rd-blender-docker
 # To build the Docker image, create the build from root directory:
-# docker build --build-arg BLENDER_VERSION=3.0 . -f Dockerfiles/Dockerfile.base_3.0 -t luciusm/blender_env:3.0
+# docker build --build-arg BLENDER_VERSION=3.0 . -f Dockerfiles/Dockerfile.base_3.0 -t <image_name>:blender3.0
 
 ARG BLENDER_VERSION=3.1
 FROM nytimes/blender:${BLENDER_VERSION}-gpu-ubuntu18.04
+
+LABEL Author="T.Tian <alchem0x2a@gmail.com>,X.Wang <xingwang1991@gmail.com>"
+LABEL Title="Blender base environment for testing beautiful-atoms"
+LABEL RepoUrl="https://github.com/beautiful-atoms/beautiful-atoms"
+LABEL ImageUrl="https://github.com/beautiful-atoms/beautiful-atoms/pkgs/container/beautiful-env"
+
+
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 

--- a/Dockerfiles/Dockerfile.base_3.x
+++ b/Dockerfiles/Dockerfile.base_3.x
@@ -28,10 +28,10 @@ RUN wget --quiet https://repo.continuum.io/miniconda/Miniconda3-py39_${MINICONDA
     conda config --system --prepend channels conda-forge && \
     conda config --system --set show_channel_urls true && \
     conda install --quiet --yes \
-                  -c conda-forge \
-                  conda=${CONDA_VERSION} \
-		  python=$PYTHON_VERSION \
-		  pip &&\
+    -c conda-forge \
+    conda=${CONDA_VERSION} \
+    python=$PYTHON_VERSION \
+    pip &&\
     conda update --all --quiet --yes &&\
     conda clean --all -f -y
 
@@ -41,11 +41,11 @@ RUN . ${CONDA_DIR}/bin/activate &&\
     yes | python install.py --generate-env-file ./env.yml ${BLENDER_PATH} &&\
     rm -rf ${BLENDER_PATH}/python &&\
     ln -s ${CONDA_DIR} ${BLENDER_PATH}/python
-    
+
 
 RUN conda env update -n base --file ./env.yml &&\
     conda clean --all -f -y &&\
-     rm -rf /tmp/*
+    rm -rf /tmp/*
 
 
 # Set the working directory

--- a/Dockerfiles/Dockerfile.main
+++ b/Dockerfiles/Dockerfile.main
@@ -3,7 +3,7 @@
 # docker build . --build-arg BLENDER_VER=3.0  \
 #                -f Dockerfiles/Dockerfile.main -t <image_name>:blender3.0
 ARG BLENDER_VER
-ARG BASE_IMAGE_NAME="ghcr.io/beautiful-atoms/beautiful-atoms"
+ARG BASE_IMAGE_NAME="ghcr.io/beautiful-atoms/blender-env"
 FROM ${BASE_IMAGE_NAME}:${BLENDER_VER}
 
 LABEL Author="T.Tian <alchem0x2a@gmail.com>,X.Wang <xingwang1991@gmail.com>"

--- a/Dockerfiles/Dockerfile.main
+++ b/Dockerfiles/Dockerfile.main
@@ -4,7 +4,7 @@
 #                -f Dockerfiles/Dockerfile.main -t <image_name>:blender3.0
 ARG BLENDER_VER
 ARG BASE_IMAGE_NAME="ghcr.io/beautiful-atoms/blender-env"
-FROM ${BASE_IMAGE_NAME}:${BLENDER_VER}
+FROM ${BASE_IMAGE_NAME}:blender${BLENDER_VER}
 
 LABEL Author="T.Tian <alchem0x2a@gmail.com>,X.Wang <xingwang1991@gmail.com>"
 LABEL Title="Conainer image for beautiful-atoms usage and developent"

--- a/Dockerfiles/Dockerfile.main
+++ b/Dockerfiles/Dockerfile.main
@@ -1,9 +1,15 @@
 # Build docker image containing blender environment + batoms
 # Please build from the root path, e.g.:
 # docker build . --build-arg BLENDER_VER=3.0  \
-#                -f Dockerfiles/Dockerfile.main -t luciusm/beautiful_atoms:blender3.0
+#                -f Dockerfiles/Dockerfile.main -t <image_name>:blender3.0
 ARG BLENDER_VER
-FROM luciusm/blender_env:${BLENDER_VER}
+ARG BASE_IMAGE_NAME="ghcr.io/beautiful-atoms/beautiful-atoms"
+FROM ${BASE_IMAGE_NAME}:${BLENDER_VER}
+
+LABEL Author="T.Tian <alchem0x2a@gmail.com>,X.Wang <xingwang1991@gmail.com>"
+LABEL Title="Conainer image for beautiful-atoms usage and developent"
+LABEL RepoUrl="https://github.com/beautiful-atoms/beautiful-atoms"
+LABEL ImageUrl="https://github.com/beautiful-atoms/beautiful-atoms/pkgs/container/beautiful-atoms"
 
 USER root
 
@@ -12,15 +18,15 @@ COPY batoms ${BLENDER_PATH}/scripts/addons_contrib/batoms
 
 # Enable batoms addon and do a simple import test
 RUN blender -b \
-            --python-exit-code 1 \
-            --python-expr  \
-            "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')" &&\
-    blender -b \
-            --python-exit-code 1 \
-            --python-expr  \
-            "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]]); print('success')"
+        --python-exit-code 1 \
+        --python-expr  \
+        "import bpy; import addon_utils; addon_utils.enable('batoms', default_set=True); bpy.ops.wm.save_userpref(); print('success')" &&\
+        blender -b \
+        --python-exit-code 1 \
+        --python-expr  \
+        "from batoms import Batoms; b = Batoms('O', ['O'], [[0, 0, 0]]); print('success')"
 
- 
+
 RUN chmod 744 -R ${BLENDER_PATH}/scripts/addons_contrib/batoms
 
 USER ${B_UID}


### PR DESCRIPTION
#112 
After this PR the images will be hosted at `ghcr.io/beautiful-atoms/beautiful-atoms:<tag>`. For backward compatibility an mirror at `luciusm/beautiful_atoms:<tag>` is still available, but the GHCR image name provides more visibility.

