### PR TITLE
Change test image to ghcr.io version in plugin test workflow

### DIFF
--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -5,11 +5,11 @@ on:
   push:
     branches: 
       - main
-      - develop
+      - workflow
   pull_request:
     branches: 
       - main
-      - develop
+      - workflow
   workflow_dispatch:
 
 env:

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -12,6 +12,9 @@ on:
       - develop
   workflow_dispatch:
 
+env:
+  TEST_IMAGE_NAME: ghcr.io/beautiful-atoms/beautiful-atoms
+
 jobs:
   basic:
     defaults:
@@ -24,7 +27,7 @@ jobs:
         blender-version: ["3.0", "3.1"]
     container:
       # Consider change to matrix versions
-      image: luciusm/blender_env:${{ matrix.blender-version }}
+      image: ${{ env.TEST_IMAGE_NAME }}:${{ matrix.blender-version }}
       # Will need pytest installation
       options: --user root
 

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEST_IMAGE_NAME: ghcr.io/beautiful-atoms/beautiful-env
+  TEST_IMAGE_NAME: ghcr.io/beautiful-atoms/blender-env
 
 jobs:
   basic:

--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEST_IMAGE_NAME: ghcr.io/beautiful-atoms/beautiful-atoms
+  TEST_IMAGE_NAME: ghcr.io/beautiful-atoms/beautiful-env
 
 jobs:
   basic:
@@ -26,8 +26,8 @@ jobs:
         # Manually change these to match the blender image versions
         blender-version: ["3.0", "3.1"]
     container:
-      # Consider change to matrix versions
-      image: ${{ env.TEST_IMAGE_NAME }}:${{ matrix.blender-version }}
+      # env is not 
+      image: ghcr.io/beautiful-atoms/blender-env:blender${{ matrix.blender-version }}
       # Will need pytest installation
       options: --user root
 

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -5,11 +5,11 @@ on:
   push:
     branches:
       - main
-      - develop
+      - workflow
   pull_request:
     branches:
       - main
-      - develop
+      - workflow
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Continuation to #116, use the ghcr.io blender-env to test the plugins. It seems with the github-hosted images, pulling is way faster than on dockerhub