### PR TITLE
Improve code in GUI panel

### DIFF
--- a/batoms/base/object.py
+++ b/batoms/base/object.py
@@ -853,11 +853,18 @@ class childObjectGN():
 
         Unfortunately, bmesh layers does not support bool, only int/float/string.
 
-        Returns:
+        Returns:    
             _type_: _description_
         """
-        
-        return self.attributes['show'].data[self.index].value
+        if self.obj.mode == 'EDIT':
+            bpy.context.view_layer.objects.active = self.obj
+            bpy.ops.object.mode_set(mode="OBJECT")
+            show = self.attributes['show'].data[self.index].value
+            bpy.ops.object.mode_set(mode="EDIT")
+            #
+        else:
+            show = self.attributes['show'].data[self.index].value
+        return show
 
     @show.setter
     def show(self, show):

--- a/batoms/base/object.py
+++ b/batoms/base/object.py
@@ -3,6 +3,7 @@ import numpy as np
 from batoms.utils.butils import (get_nodes_by_name, object_mode, set_look_at,
                                  update_object)
 from time import time
+import bmesh
 import logging
 
 # logger = logging.getLogger('batoms')
@@ -752,14 +753,38 @@ class childObjectGN():
         self.label = label
         self.index = index
         self.parent = parent
+        self.obj_name = label
+
+    @property
+    def obj(self):
+        return self.get_obj()
+
+    def get_obj(self):
+        obj = bpy.data.objects.get(self.obj_name)
+        if obj is None:
+            raise KeyError('%s object is not exist.' % self.obj_name)
+        return obj
 
     @property
     def vertice(self):
-        return self.parent.obj.data.shape_keys.key_blocks[0].data[self.index]
+        return self.obj.data.shape_keys.key_blocks[0].data[self.index]
+
+    @property
+    def bm(self):
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+        else:
+            bm = bmesh.new()
+            bm.from_mesh(self.obj.data)
+        return bm
+
+    @property
+    def bm_vert(self):
+        return self.bm.verts[self.index]
 
     @property
     def attributes(self):
-        return self.parent.obj.data.attributes
+        return self.obj.data.attributes
 
     @property
     def local_position(self):
@@ -779,7 +804,7 @@ class childObjectGN():
         """
         from batoms.utils import local2global
         position = local2global(np.array([self.local_position]),
-                                np.array(self.parent.obj.matrix_world))
+                                np.array(self.obj.matrix_world))
         return position[0]
 
     def set_position(self, position):
@@ -790,20 +815,46 @@ class childObjectGN():
         from batoms.utils import local2global
         position = np.array([position])
         position = local2global(position,
-                                np.array(self.parent.obj.matrix_world),
+                                np.array(self.obj.matrix_world),
                                 reversed=True)
         # rashpe to (natoms*3, 1) and use forseach_set
         self.vertice.co = position[0]
-        self.parent.obj.data.update()
-        update_object(self.parent.obj)
+        self.obj.data.update()
+        update_object(self.obj)
 
     @property
     def scale(self):
-        return self.attributes['scale'].data[self.index].value
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.float.get("scale")
+            scale = bm.verts[self.index][layer]
+        else:
+            bm = bmesh.new()
+            bm.from_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.float.get("scale")
+            scale = bm.verts[self.index][layer]
+            bm.free()
+        return scale
 
     @scale.setter
     def scale(self, scale):
-        self.attributes['scale'].data[self.index].value = scale
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.float.get("scale")
+            bm.verts[self.index][layer] = scale
+            bmesh.update_edit_mesh(self.obj.data)
+        else:
+            bm = bmesh.new()
+            bm.from_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.float.get("scale")
+            bm.verts[self.index][layer] = scale
+            bm.to_mesh(self.obj.data)
+            # self.obj.data.update()
+            bm.free()
 
     @property
     def show(self):
@@ -812,4 +863,4 @@ class childObjectGN():
     @show.setter
     def show(self, show):
         self.attributes['show'].data[self.index].value = show
-        update_object(self.parent.obj)
+        update_object(self.obj)

--- a/batoms/base/object.py
+++ b/batoms/base/object.py
@@ -749,11 +749,14 @@ class childObjectGN():
 
     """
 
-    def __init__(self, label, index, parent=None):
+    def __init__(self, label, index, obj_name=None, parent=None):
         self.label = label
         self.index = index
         self.parent = parent
-        self.obj_name = label
+        if obj_name is None:
+            self.obj_name = label
+        else:
+            self.obj_name = obj_name
 
     @property
     def obj(self):
@@ -830,12 +833,7 @@ class childObjectGN():
             layer = bm.verts.layers.float.get("scale")
             scale = bm.verts[self.index][layer]
         else:
-            bm = bmesh.new()
-            bm.from_mesh(self.obj.data)
-            bm.verts.ensure_lookup_table()
-            layer = bm.verts.layers.float.get("scale")
-            scale = bm.verts[self.index][layer]
-            bm.free()
+            scale = self.attributes['scale'].data[self.index].value
         return scale
 
     @scale.setter
@@ -847,17 +845,18 @@ class childObjectGN():
             bm.verts[self.index][layer] = scale
             bmesh.update_edit_mesh(self.obj.data)
         else:
-            bm = bmesh.new()
-            bm.from_mesh(self.obj.data)
-            bm.verts.ensure_lookup_table()
-            layer = bm.verts.layers.float.get("scale")
-            bm.verts[self.index][layer] = scale
-            bm.to_mesh(self.obj.data)
-            # self.obj.data.update()
-            bm.free()
+            self.attributes['scale'].data[self.index].value = scale
 
     @property
     def show(self):
+        """_summary_
+
+        Unfortunately, bmesh layers does not support bool, only int/float/string.
+
+        Returns:
+            _type_: _description_
+        """
+        
         return self.attributes['show'].data[self.index].value
 
     @show.setter

--- a/batoms/batom.py
+++ b/batoms/batom.py
@@ -10,6 +10,9 @@ class Batom(childObjectGN):
     def __init__(self, label, index=0, batoms=None) -> None:
         """Batom class
 
+        Access properties of one atoms by reading attribute 
+        from obj directly. This will be faster than Batoms[index]
+
         Args:
             label (str):
                 Name of the Batoms object
@@ -21,11 +24,11 @@ class Batom(childObjectGN):
         childObjectGN.__init__(self, label, index, parent=batoms)
 
     def __repr__(self):
-        bpy.context.view_layer.objects.active = self.parent.obj
-        mode = self.parent.obj.mode
+        bpy.context.view_layer.objects.active = self.obj
+        mode = self.obj.mode
         bpy.ops.object.mode_set(mode='OBJECT')
         s = "Batom(species = '%s', " % self.species
-        s += "elements = %s, " % str(self.elements)
+        # s += "elements = %s, " % str(self.elements)
         s += "positions = %s)" % np.round(self.position, 2)
         bpy.ops.object.mode_set(mode=mode)
         return s

--- a/batoms/bond/bond.py
+++ b/batoms/bond/bond.py
@@ -1,4 +1,5 @@
 import bpy
+import bmesh
 import numpy as np
 from batoms.utils import number2String
 from batoms.base.object import childObjectGN
@@ -11,7 +12,9 @@ class Bond(childObjectGN):
     """
 
     def __init__(self, label, index=0, bonds=None) -> None:
-        childObjectGN.__init__(self, label, index, parent=bonds)
+        childObjectGN.__init__(self, label, index,
+                    obj_name="{}_bond".format(label),
+                    parent=bonds)
 
     def __repr__(self):
         bpy.context.view_layer.objects.active = self.parent.obj
@@ -47,11 +50,24 @@ class Bond(childObjectGN):
 
     @property
     def order(self):
-        return self.attributes['order'].data[self.index].value
-
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.int.get("order")
+            order = bm.verts[self.index][layer]
+        else:
+            order = self.attributes['order'].data[self.index].value
+        return order
     @order.setter
     def order(self, order):
-        self.attributes['order'].data[self.index].value = order
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.int.get("order")
+            bm.verts[self.index][layer] = order
+            bmesh.update_edit_mesh(self.obj.data)
+        else:
+            self.attributes['order'].data[self.index].value = int(order)
         # find plane for high order
         a3, a4 = self.secondBond()
         self.attributes['atoms_index3'].data[self.index].value = a3
@@ -64,11 +80,25 @@ class Bond(childObjectGN):
 
     @property
     def style(self):
-        return self.attributes['style'].data[self.index].value
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.int.get("style")
+            style = bm.verts[self.index][layer]
+        else:
+            style = self.attributes['style'].data[self.index].value
+        return style
 
     @style.setter
     def style(self, style):
-        self.attributes['style'].data[self.index].value = int(style)
+        if self.obj.mode == 'EDIT':
+            bm =bmesh.from_edit_mesh(self.obj.data)
+            bm.verts.ensure_lookup_table()
+            layer = bm.verts.layers.int.get("style")
+            bm.verts[self.index][layer] = style
+            bmesh.update_edit_mesh(self.obj.data)
+        else:
+            self.attributes['style'].data[self.index].value = int(style)
         # if stule not exist, add one
         sp = self.species
         sp['style'] = style

--- a/batoms/bond/bond.py
+++ b/batoms/bond/bond.py
@@ -3,6 +3,7 @@ import bmesh
 import numpy as np
 from batoms.utils import number2String
 from batoms.base.object import childObjectGN
+import time
 import logging
 # logger = logging.getLogger('batoms')
 logger = logging.getLogger(__name__)
@@ -51,6 +52,11 @@ class Bond(childObjectGN):
     @property
     def order(self):
         if self.obj.mode == 'EDIT':
+            # bpy.context.view_layer.objects.active = self.obj
+            # bpy.ops.object.mode_set(mode="OBJECT")
+            # order = self.attributes['order'].data[self.index].value
+            # bpy.ops.object.mode_set(mode="EDIT")
+            #
             bm =bmesh.from_edit_mesh(self.obj.data)
             bm.verts.ensure_lookup_table()
             layer = bm.verts.layers.int.get("order")
@@ -58,6 +64,7 @@ class Bond(childObjectGN):
         else:
             order = self.attributes['order'].data[self.index].value
         return order
+
     @order.setter
     def order(self, order):
         if self.obj.mode == 'EDIT':
@@ -81,10 +88,20 @@ class Bond(childObjectGN):
     @property
     def style(self):
         if self.obj.mode == 'EDIT':
+            # tstart = time.time()
+            # bpy.context.view_layer.objects.active = self.obj
+            # bpy.ops.object.mode_set(mode="OBJECT")
+            # style = self.attributes['style'].data[self.index].value
+            # bpy.ops.object.mode_set(mode="EDIT")
+            # t1 = time.time() - tstart
+            #
+            # tstart = time.time()
             bm =bmesh.from_edit_mesh(self.obj.data)
             bm.verts.ensure_lookup_table()
             layer = bm.verts.layers.int.get("style")
             style = bm.verts[self.index][layer]
+            # t2 = time.time() - tstart
+            # print("mode: {}, bmesh: {}".format(t1, t2))
         else:
             style = self.attributes['style'].data[self.index].value
         return style

--- a/batoms/gui/__init__.py
+++ b/batoms/gui/__init__.py
@@ -24,6 +24,21 @@ from . import (
     view3d_mt_batoms_add,
 )
 
+class BatomsCollection(bpy.types.PropertyGroup):
+    """
+    Collection properties of all panel properties.
+    """
+    batoms: PointerProperty(type=gui_batoms.BatomsProperties)
+    batom: PointerProperty(type=gui_batom.BatomProperties)
+    cell: PointerProperty(type=gui_cell.CellProperties)
+    bond: PointerProperty(type=gui_bond.BondProperties)
+    plane: PointerProperty(type=gui_plane.PlaneProperties)
+    render: PointerProperty(type=gui_render.RenderProperties)
+    pymatgen: PointerProperty(type=gui_pymatgen.PymatgenProperties)
+    pubchem: PointerProperty(type=gui_pubchem.PubchemProperties)
+    rscb: PointerProperty(type=gui_rscb.RSCBProperties)
+
+
 classes = [
     gui_batoms.Batoms_PT_prepare,
     gui_batoms.BatomsProperties,
@@ -78,22 +93,17 @@ classes = [
     ui_list_magres.BATOMS_MT_magres_context_menu,
     ui_list_magres.BATOMS_UL_magres,
     ui_list_magres.BATOMS_PT_magres,
+    BatomsCollection,
 ]
+
+
 
 def register_class():
     from bpy.utils import register_class
     for cls in classes:
         register_class(cls)
     scene = bpy.types.Scene
-    scene.bapanel = PointerProperty(type=gui_batoms.BatomsProperties)
-    scene.btpanel = PointerProperty(type=gui_batom.BatomProperties)
-    scene.clpanel = PointerProperty(type=gui_cell.CellProperties)
-    scene.bbpanel = PointerProperty(type=gui_bond.BondProperties)
-    scene.plpanel = PointerProperty(type=gui_plane.PlaneProperties)
-    scene.repanel = PointerProperty(type=gui_render.RenderProperties)
-    scene.pmgpanel = PointerProperty(type=gui_pymatgen.PymatgenProperties)
-    scene.pubcpanel = PointerProperty(type=gui_pubchem.PubchemProperties)
-    
+    scene.batoms = PointerProperty(type=BatomsCollection)
 
 
 def unregister_class():
@@ -101,14 +111,8 @@ def unregister_class():
     for cls in reversed(classes):
         unregister_class(cls)
     scene = bpy.types.Scene
-    del scene.bapanel
-    del scene.btpanel
-    del scene.clpanel
-    del scene.bbpanel
-    del scene.plpanel
-    del scene.repanel
-    del scene.pmgpanel
-    del scene.pubcpanel
+    del scene.batoms
+
 
 def register_menu():
     bpy.types.VIEW3D_MT_add.prepend(view3d_mt_batoms_add.menu_func)

--- a/batoms/gui/gui_batom.py
+++ b/batoms/gui/gui_batom.py
@@ -17,12 +17,16 @@ class Batom_PT_prepare(Panel):
     bl_category = "Species"
     bl_idname = "BATOMS_PT_Batom"
 
+    # @classmethod    
+    # def poll(cls, context):
+        # return (context.object.mode == "EDIT")
+
     def draw(self, context):
         layout = self.layout
-        btpanel = context.scene.btpanel
-        layout.prop(btpanel, "scale")
-        layout.prop(btpanel, "show")
-        layout.prop(btpanel, "bond")
+        batom = context.scene.batoms.batom
+        layout.prop(batom, "scale")
+        layout.prop(batom, "show")
+        layout.prop(batom, "bond")
 
 
 
@@ -32,6 +36,8 @@ def get_scale(self):
         v = get_selected_vertices_bmesh(batoms.obj)
         if len(v) > 0:
             return batoms.scale[v[0]]
+        else:
+            return 0
     else:
         return 0
 
@@ -42,18 +48,18 @@ def set_scale(self, value):
 class BatomProperties(bpy.types.PropertyGroup):
 
     def Callback_modify_size(self, context):
-        btpanel = bpy.context.scene.btpanel
-        size = btpanel.size
+        batom = bpy.context.scene.batoms.batom
+        size = batom.size
         bpy.ops.batoms.batom_modify(key='size', size=size)
 
     def Callback_modify_bond(self, context):
-        btpanel = bpy.context.scene.btpanel
-        bond = btpanel.bond
+        batom = bpy.context.scene.batom
+        bond = batom.bond
         bpy.ops.batoms.batom_modify(key='bond', bond=bond)
 
     def Callback_modify_show(self, context):
-        btpanel = bpy.context.scene.btpanel
-        show = btpanel.show
+        batom = bpy.context.scene.batom
+        show = batom.show
         bpy.ops.batoms.batom_modify(key='show', show=show)
 
     scale: FloatProperty(

--- a/batoms/gui/gui_batom.py
+++ b/batoms/gui/gui_batom.py
@@ -23,7 +23,7 @@ class Batom_PT_prepare(Panel):
     # def poll(cls, context):
     #     obj = context.object
     #     if obj:
-    #         return obj.batoms.type == 'BATOMS' and obj.mode == 'EDIT'
+    #         return obj.batoms.type == 'BATOMS' and obj.mode != 'EDIT'
     #     else:
     #         return False
 

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -33,23 +33,23 @@ class Batoms_PT_prepare(Panel):
         layout.operator("batoms.import")
         layout.operator("batoms.export")
 
-        bapanel = context.scene.bapanel
+        batoms = context.scene.batoms.batoms
 
         layout.label(text="Model style")
         col = layout.column()
-        col.prop(bapanel, "model_style", expand=True)
+        col.prop(batoms, "model_style", expand=True)
         # layout.label(text="Add label")
         layout.label(text="Radius style")
-        layout.prop(bapanel, "radius_style", expand=True)
+        layout.prop(batoms, "radius_style", expand=True)
         layout.label(text="Color style")
-        layout.prop(bapanel, "color_style", expand=True)
+        layout.prop(batoms, "color_style", expand=True)
         layout.label(text="Polyhedra style")
-        layout.prop(bapanel, "polyhedra_style", expand=True)
+        layout.prop(batoms, "polyhedra_style", expand=True)
 
-        layout.prop(bapanel, "show", expand=True)
-        layout.prop(bapanel, "wrap", expand=True)
-        layout.prop(bapanel, "show_label", expand=True, text="label")
-        layout.prop(bapanel, "scale")
+        layout.prop(batoms, "show", expand=True)
+        layout.prop(batoms, "wrap", expand=True)
+        layout.prop(batoms, "show_label", expand=True, text="label")
+        layout.prop(batoms, "scale")
 
         layout.operator("batoms.replace")
 

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -105,7 +105,7 @@ def modify_batoms_attr(context, key, value):
         bpy.context.view_layer.objects.active = batoms.obj
 
 
-def get_enum_attr(name):
+def get_enum_attr(name, func):
     """Helper function to easily get enum property.
 
     Args:
@@ -113,7 +113,7 @@ def get_enum_attr(name):
     """
 
     def getter(self):
-        batoms = get_active_collection()
+        batoms = func()
         if batoms is not None:
             return int(getattr(batoms, name))
         else:
@@ -183,7 +183,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         name="model_style",
         description="Structural models",
         items=model_style_items,
-        get=get_enum_attr("model_style"),
+        get=get_enum_attr("model_style", get_active_collection),
         set=set_enum_attr("model_style"),
         default=0,
     )
@@ -202,7 +202,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("Covalent", "covalent", "", 0),
                ("VDW", "van der Waals", "", 1),
                ("Ionic", "ionic", "", 2)),
-        get=get_enum_attr("radius_style"),
+        get=get_enum_attr("radius_style", get_active_collection),
         set=set_enum_attr("radius_style"),
         default=0,
     )
@@ -213,7 +213,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("JMOL", "JMOL", "", 0),
                ("VESTA", "VESTA", "", 1),
                ("CPK", "CPK", "", 2)),
-        get=get_enum_attr("color_style"),
+        get=get_enum_attr("color_style", get_active_collection),
         set=set_enum_attr("color_style"),
         default=0,
     )
@@ -225,7 +225,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("1", "atoms, polyhedra", "", 1),
                ("2", "central atoms, polyhedra", "", 2),
                ("3", "polyhedra", "", 3)),
-        get=get_enum_attr("polyhedra_style"),
+        get=get_enum_attr("polyhedra_style", get_active_collection),
         set=set_enum_attr("polyhedra_style"),
         default=0,
     )

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -1,3 +1,6 @@
+""" 
+#TODO wrap is 3d vector, do we need support all?
+"""
 import bpy
 from bpy.types import Panel
 from bpy.props import (
@@ -54,90 +57,64 @@ class Batoms_PT_prepare(Panel):
         layout.operator("batoms.replace")
 
 
-def get_model_style(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return int(batoms.model_style)
-    else:
-        return 0
+def get_enum_attr(name):
+    """Helper function to easily get enum property.
 
-def set_model_style(self, value):
-    items = self.bl_rna.properties["model_style"].enum_items
-    item = items[value]
-    model_style = item.identifier
-    # print(model_style)
-    self["model_style"] = model_style
-    set_batoms_attr('model_style', value)
+    Args:
+        name (str): name of the attribute
+    """
+    def getter(self):
+        batoms = get_active_collection()
+        if batoms is not None:
+            return int(getattr(batoms, name))
+        else:
+            return 0
+        
+    return getter
 
+def set_enum_attr(name):
+    """Helper function to easily set enum property.
 
-def get_radius_style(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return int(batoms.radius_style)
-    else:
-        return 0
-
-def set_radius_style(self, value):
-    items = self.bl_rna.properties["radius_style"].enum_items
-    item = items[value]
-    radius_style = item.identifier
-    # print(radius_style)
-    self["radius_style"] = radius_style
-    set_batoms_attr('radius_style', value)
-
-
-def get_color_style(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return int(batoms.color_style)
-    else:
-        return 0
-
-def set_color_style(self, value):
-    items = self.bl_rna.properties["color_style"].enum_items
-    item = items[value]
-    color_style = item.identifier
-    # print(color_style)
-    self["color_style"] = color_style
-    set_batoms_attr('color_style', value)
+    Args:
+        name (str): name of the attribute
+    """
+    def setter(self, value):
+        items = self.bl_rna.properties[name].enum_items
+        item = items[value]
+        identifier = item.identifier
+        self[name] = identifier
+        set_batoms_attr(name, value)
+    
+    return setter
 
 
-def get_polyhedra_style(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return int(batoms.polyhedra_style)
-    else:
-        return 0
+def get_attr(name):
+    """Helper function to easily get property.
 
-def set_polyhedra_style(self, value):
-    items = self.bl_rna.properties["polyhedra_style"].enum_items
-    item = items[value]
-    polyhedra_style = item.identifier
-    # print(polyhedra_style)
-    self["polyhedra_style"] = polyhedra_style
-    set_batoms_attr('polyhedra_style', value)
+    Args:
+        name (str): name of the attribute
+    """
+    def getter(self):
+        batoms = get_active_collection()
+        if batoms is not None:
+            return getattr(batoms, name)
+        else:
+            prop = self.bl_rna.properties[name]
+            return prop.default
+    return getter
 
-def get_show_label(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return batoms.show_label
-    else:
-        return ""
+def set_attr(name):
+    """Helper function to easily set property.
 
-def set_show_label(self, value):
-    self["show_label"] = value
-    set_batoms_attr('show_label', value)
+    Args:
+        name (str): name of the attribute
+    """
+    def setter(self, value):
+        self[name] = value
+        set_batoms_attr(name, value)
+    
+    return setter
 
-def get_show(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return batoms.show
-    else:
-        return False
-
-def set_show(self, value):
-    self["show"] = value
-    set_batoms_attr('show', value)
 
 def get_wrap(self):
     batoms = get_active_collection()
@@ -146,36 +123,22 @@ def get_wrap(self):
     else:
         return 0
 
-def set_wrap(self, value):
-    self["wrap"] = value
-    set_batoms_attr('wrap', value)
-
-def get_scale(self):
-    batoms = get_active_collection()
-    if batoms is not None:
-        return batoms.scale
-    else:
-        return 0
-
-def set_scale(self, value):
-    self["scale"] = value
-    set_batoms_attr('scale', value)
 
 class BatomsProperties(bpy.types.PropertyGroup):
     model_style: EnumProperty(
         name="model_style",
         description="Structural models",
         items=model_style_items,
-        get=get_model_style,
-        set=set_model_style,
+        get=get_enum_attr("model_style"),
+        set=set_enum_attr("model_style"),
         default=0,
     )
 
     show_label: StringProperty(
         name="label",
         description="Show label: None, Index, Species or Charge and so on",
-        get=get_show_label,
-        set=set_show_label,
+        get=get_attr("show_label"),
+        set=set_attr("show_label"),
         default="",
     )
 
@@ -185,8 +148,8 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("Covalent", "covalent", "", 0),
                ("VDW", "van der Waals", "", 1),
                ("Ionic", "ionic", "", 2)),
-        get=get_radius_style,
-        set=set_radius_style,
+        get=get_enum_attr("radius_style"),
+        set=set_enum_attr("radius_style"),
         default=0,
     )
 
@@ -196,8 +159,8 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("JMOL", "JMOL", "", 0),
                ("VESTA", "VESTA", "", 1),
                ("CPK", "CPK", "", 2)),
-        get=get_color_style,
-        set=set_color_style,
+        get=get_enum_attr("color_style"),
+        set=set_enum_attr("color_style"),
         default=0,
     )
 
@@ -208,29 +171,29 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("1", "atoms, polyhedra", "", 1),
                ("2", "central atoms, polyhedra", "", 2),
                ("3", "polyhedra", "", 3)),
-        get=get_polyhedra_style,
-        set=set_polyhedra_style,
+        get=get_enum_attr("polyhedra_style"),
+        set=set_enum_attr("polyhedra_style"),
         default=0,
     )
 
     show: BoolProperty(name="show",
                        default=False,
                        description="show all object for view and rendering",
-                       get=get_show,
-                       set=set_show)
+                       get=get_attr("show"),
+                       set=set_attr("show"))
 
     wrap: BoolProperty(name="wrap",
                        default=False,
                        description="wrap all atoms into cell",
                        get=get_wrap,
-                       set=set_wrap,)
+                       set=set_attr("wrap"),)
 
     scale: FloatProperty(
         name="scale", default=1.0,
         min=0.0, soft_max=2.0,
         description="scale",
-        get=get_scale,
-        set=set_scale,)
+        get=get_attr("scale"),
+        set=set_attr("scale"),)
 
 
 def get_active_collection():

--- a/batoms/gui/gui_bond.py
+++ b/batoms/gui/gui_bond.py
@@ -18,37 +18,37 @@ class Bond_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        bbpanel = context.scene.bbpanel
+        bond = context.scene.batoms.bond
 
         layout.operator("bond.bond_order_auto_set", icon='MODIFIER_ON', text="Auto Set Bond Order")
         layout.separator()
         layout.label(text="Bond style")
         col = layout.column()
-        col.prop(bbpanel, "bond_style", expand=True)
-        layout.prop(bbpanel, "bondwidth")
-        layout.prop(bbpanel, "order")
-        layout.prop(bbpanel, "show")
+        col.prop(bond, "bond_style", expand=True)
+        layout.prop(bond, "bondwidth")
+        layout.prop(bond, "order")
+        layout.prop(bond, "show")
 
 
 class BondProperties(bpy.types.PropertyGroup):
     def Callback_bond_style(self, context):
-        bbpanel = bpy.context.scene.bbpanel
-        bond_style = list(bbpanel.bond_style)[0]
+        bond = bpy.context.scene.batoms.bond
+        bond_style = list(bond.bond_style)[0]
         bpy.ops.bond.bond_modify(key='style', style=bond_style)
 
     def Callback_modify_bondwidth(self, context):
-        bbpanel = bpy.context.scene.bbpanel
-        bondwidth = bbpanel.bondwidth
+        bond = bpy.context.scene.batoms.bond
+        bondwidth = bond.bondwidth
         bpy.ops.bond.bond_modify(key='width', bondwidth=bondwidth)
 
     def Callback_modify_show(self, context):
-        bbpanel = bpy.context.scene.bbpanel
-        show = bbpanel.show
+        bond = bpy.context.scene.batoms.bond
+        show = bond.show
         bpy.ops.bond.bond_modify(key='show', show=show)
 
     def Callback_modify_order(self, context):
-        bbpanel = bpy.context.scene.bbpanel
-        order = bbpanel.order
+        bond = bpy.context.scene.batoms.bond
+        order = bond.order
         bpy.ops.bond.bond_modify(key='order', order=order)
 
     bond_style: EnumProperty(

--- a/batoms/gui/gui_bond.py
+++ b/batoms/gui/gui_bond.py
@@ -20,6 +20,14 @@ class Bond_PT_prepare(Panel):
     bl_category = "Bond"
     bl_idname = "BATOMS_PT_Bond"
 
+    # @classmethod
+    # def poll(cls, context):
+    #     obj = context.object
+    #     if obj:
+    #         return obj.batoms.type == 'BOND' and obj.mode != 'EDIT'
+    #     else:
+    #         return False
+    
     def draw(self, context):
         layout = self.layout
         bond = context.scene.batoms.bond
@@ -36,7 +44,7 @@ class Bond_PT_prepare(Panel):
 # ---------------------------------------------------
 def get_active_bond():
     context = bpy.context
-    if context.object and context.object.batoms.type != 'OTHER':
+    if context.object and context.object.batoms.type == 'BOND':
         v = get_selected_vertices(context.object)
         if len(v) > 0:
             bond = Bond(label=context.object.batoms.label, index=v[0])
@@ -54,7 +62,7 @@ def set_bond_attr_by_batoms(key):
             batoms = Batoms(label=bond.label)
             setattr(batoms.bonds[bond.index], key, value)
             # bpy.ops.object.mode_set(mode="EDIT")
-            # bpy.context.view_layer.objects.active = batom.obj
+            bpy.context.view_layer.objects.active = batoms.bonds.obj
     
     return setter
 
@@ -65,9 +73,12 @@ def get_bond_attr(key):
         bond = get_active_bond()
         if bond is not None:
             batoms = Batoms(label=bond.label)
-            return getattr(batoms.bonds[bond.index], key)
+            # bpy.context.view_layer.objects.active = batoms.bonds.obj
+            value = getattr(batoms.bonds[bond.index], key)
             # bpy.ops.object.mode_set(mode="EDIT")
-            # bpy.context.view_layer.objects.active = batom.obj
+            return value
+        else:
+            return self.bl_rna.properties[key].default
     
     return getter
 
@@ -102,6 +113,6 @@ class BondProperties(bpy.types.PropertyGroup):
                        set=set_bond_attr_by_batoms("order"),
                        )
     show: BoolProperty(name="show", default=False,
-                        get=get_attr("show", get_active_bond),
-                        set=set_bond_attr_by_batoms("show"),    
-                        )
+                       get=get_attr("show", get_active_bond),
+                       set=set_bond_attr_by_batoms("show"),    
+                       )

--- a/batoms/gui/gui_cell.py
+++ b/batoms/gui/gui_cell.py
@@ -22,10 +22,6 @@ class Cell_PT_prepare(Panel):
         layout = self.layout
         cell = context.scene.batoms.cell
 
-        # op = layout.operator("batoms.apply_cell")
-        # op.a = [cell.cell_a0, cell.cell_a1, cell.cell_a2]
-        # op.b = [cell.cell_b0, cell.cell_b1, cell.cell_b2]
-        # op.c = [cell.cell_c0, cell.cell_c1, cell.cell_c2]
         box = layout.box()
         row = box.row(align = True)
         row.prop(cell, "cell_a0")

--- a/batoms/gui/gui_cell.py
+++ b/batoms/gui/gui_cell.py
@@ -20,42 +20,42 @@ class Cell_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        clpanel = context.scene.clpanel
+        cell = context.scene.batoms.cell
 
         # op = layout.operator("batoms.apply_cell")
-        # op.a = [clpanel.cell_a0, clpanel.cell_a1, clpanel.cell_a2]
-        # op.b = [clpanel.cell_b0, clpanel.cell_b1, clpanel.cell_b2]
-        # op.c = [clpanel.cell_c0, clpanel.cell_c1, clpanel.cell_c2]
+        # op.a = [cell.cell_a0, cell.cell_a1, cell.cell_a2]
+        # op.b = [cell.cell_b0, cell.cell_b1, cell.cell_b2]
+        # op.c = [cell.cell_c0, cell.cell_c1, cell.cell_c2]
         box = layout.box()
         row = box.row(align = True)
-        row.prop(clpanel, "cell_a0")
-        row.prop(clpanel, "cell_a1")
-        row.prop(clpanel, "cell_a2")
+        row.prop(cell, "cell_a0")
+        row.prop(cell, "cell_a1")
+        row.prop(cell, "cell_a2")
         row = box.row(align = True)
-        row.prop(clpanel, "cell_b0")
-        row.prop(clpanel, "cell_b1")
-        row.prop(clpanel, "cell_b2")
+        row.prop(cell, "cell_b0")
+        row.prop(cell, "cell_b1")
+        row.prop(cell, "cell_b2")
         row = box.row(align = True)
-        row.prop(clpanel, "cell_c0")
-        row.prop(clpanel, "cell_c1")
-        row.prop(clpanel, "cell_c2")
-        layout.prop(clpanel, "pbc")
+        row.prop(cell, "cell_c0")
+        row.prop(cell, "cell_c1")
+        row.prop(cell, "cell_c2")
+        layout.prop(cell, "pbc")
 
         op = layout.operator("batoms.apply_transform")
-        op.a = clpanel.transform_a
-        op.b = clpanel.transform_b
-        op.c = clpanel.transform_c
-        layout.prop(clpanel, "transform_a")
-        layout.prop(clpanel, "transform_b")
-        layout.prop(clpanel, "transform_c")
+        op.a = cell.transform_a
+        op.b = cell.transform_b
+        op.c = cell.transform_c
+        layout.prop(cell, "transform_a")
+        layout.prop(cell, "transform_b")
+        layout.prop(cell, "transform_c")
         #
         op = layout.operator("batoms.apply_boundary")
-        op.a = clpanel.boundary_a
-        op.b = clpanel.boundary_b
-        op.c = clpanel.boundary_c
-        layout.prop(clpanel, "boundary_a")
-        layout.prop(clpanel, "boundary_b")
-        layout.prop(clpanel, "boundary_c")
+        op.a = cell.boundary_a
+        op.b = cell.boundary_b
+        op.c = cell.boundary_c
+        layout.prop(cell, "boundary_a")
+        layout.prop(cell, "boundary_b")
+        layout.prop(cell, "boundary_c")
 
 def get_cell(i1, i2):
     """Helper function to easily get cell-property."""
@@ -87,8 +87,8 @@ class CellProperties(bpy.types.PropertyGroup):
         return None
 
     def Callback_modify_pbc(self, context):
-        clpanel = bpy.context.scene.clpanel
-        pbc = clpanel.pbc
+        cell = bpy.context.scene.batoms.cell
+        pbc = cell.pbc
         modify_batoms_attr(self.selected_batoms(context), 'pbc', pbc)
 
     pbc: BoolProperty(

--- a/batoms/gui/gui_plane.py
+++ b/batoms/gui/gui_plane.py
@@ -20,21 +20,21 @@ class Plane_PT_prepare(Panel):
     bl_idname = "PLANE_PT_Tools"
 
     def draw(self, context):
-        plpanel = context.scene.plpanel
+        plane = context.scene.batoms.plane
         
         layout = self.layout
         row = layout.row()
-        row.prop(plpanel, "indices")
-        layout.prop(plpanel, "distance")
-        layout.prop(plpanel, "scale")
-        layout.prop(plpanel, "symmetry", expand  = True)
+        row.prop(plane, "indices")
+        layout.prop(plane, "distance")
+        layout.prop(plane, "scale")
+        layout.prop(plane, "symmetry", expand  = True)
         row = layout.row()
-        row.prop(plpanel, "crystal")
-        row.prop(plpanel, "center")
-        layout.prop(plpanel, "slicing", expand  = True)
-        layout.prop(plpanel, "boundary", expand  = True)
-        layout.prop(plpanel, "show_edge")
-        layout.prop(plpanel, "color")
+        row.prop(plane, "crystal")
+        row.prop(plane, "center")
+        layout.prop(plane, "slicing", expand  = True)
+        layout.prop(plane, "boundary", expand  = True)
+        layout.prop(plane, "show_edge")
+        layout.prop(plane, "color")
         layout.operator("batoms.add_plane")
 
 
@@ -47,45 +47,45 @@ class PlaneProperties(bpy.types.PropertyGroup):
     def selected_plane(self):
         return get_selected_objects('bplane')
     def Callback_modify_indices(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'indices', plpanel.indices)
+                    self.selected_plane, 'indices', plane.indices)
     def Callback_modify_distance(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'distance', plpanel.distance)
+                    self.selected_plane, 'distance', plane.distance)
     def Callback_modify_scale(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'scale', plpanel.scale)
+                    self.selected_plane, 'scale', plane.scale)
     def Callback_modify_crystal(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'crystal', plpanel.crystal, center = plpanel.center)
+                    self.selected_plane, 'crystal', plane.crystal, center = plane.center)
     def Callback_modify_center(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'center', plpanel.center)
+                    self.selected_plane, 'center', plane.center)
     def Callback_modify_symmetry(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'symmetry', plpanel.symmetry)
+                    self.selected_plane, 'symmetry', plane.symmetry)
     def Callback_modify_slicing(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'slicing', plpanel.slicing)
+                    self.selected_plane, 'slicing', plane.slicing)
     def Callback_modify_boundary(self, context):
-        plpanel = bpy.context.scene.plpanel
+        plane = bpy.context.scene.batoms.plane
         modify_plane_attr(self.selected_batoms, 
-                    self.selected_plane, 'boundary', plpanel.boundary)
+                    self.selected_plane, 'boundary', plane.boundary)
     def Callback_modify_show_edge(self, context):
-        plpanel = bpy.context.scene.plpanel
-        show_edge = plpanel.show_edge
+        plane = bpy.context.scene.batoms.plane
+        show_edge = plane.show_edge
         modify_plane_attr(self.selected_batoms, 
                     self.selected_plane, 'show_edge', show_edge)
     def Callback_modify_color(self, context):
-        plpanel = bpy.context.scene.plpanel
-        color = plpanel.color
+        plane = bpy.context.scene.batoms.plane
+        color = plane.color
         modify_plane_attr(self.selected_batoms, 
                     self.selected_plane, 'color', color)
 
@@ -131,11 +131,11 @@ class PlaneProperties(bpy.types.PropertyGroup):
         update = Callback_modify_color)
     
 
-def modify_plane_attr(batoms_name_list, plpanel_name_list, key, value, center = False):
+def modify_plane_attr(batoms_name_list, plane_name_list, key, value, center = False):
     selected_plane_new = []
     for batoms_name in batoms_name_list:
         batoms = Batoms(label = batoms_name)
-        for plane_name in plpanel_name_list:
+        for plane_name in plane_name_list:
             plane = bpy.data.objects[plane_name]
             if plane.bplane.label == batoms_name:
                 batoms.planesetting[plane.bplane.indices] = {key: value}

--- a/batoms/gui/gui_pubchem.py
+++ b/batoms/gui/gui_pubchem.py
@@ -15,10 +15,10 @@ class Pubchem_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        pubcpanel = context.scene.pubcpanel
+        pubchem = context.scene.batoms.pubchem
 
         layout.label(text="Search structure")
-        layout.prop(pubcpanel, "cid")
+        layout.prop(pubchem, "cid")
         layout.operator("batoms.pubchem_search")
 
 
@@ -35,6 +35,6 @@ class Search(Operator):
     bl_description = ("Search structure by id")
 
     def execute(self, context):
-        pubcpanel = context.scene.pubcpanel
-        batoms = pubchem_search(pubcpanel.cid)
+        pubchem = context.scene.batoms.pubchem
+        batoms = pubchem_search(pubchem.cid)
         return {'FINISHED'}

--- a/batoms/gui/gui_pymatgen.py
+++ b/batoms/gui/gui_pymatgen.py
@@ -17,11 +17,11 @@ class Pymatgen_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        pmgpanel = context.scene.pmgpanel
+        pymatgen = context.scene.batoms.pymatgen
 
         layout.label(text="Search structure")
-        layout.prop(pmgpanel, "key")
-        layout.prop(pmgpanel, "id")
+        layout.prop(pymatgen, "key")
+        layout.prop(pymatgen, "id")
         layout.operator("batoms.pymatgen_search")
 
 
@@ -41,6 +41,6 @@ class Search(Operator):
     bl_description = ("Search structure by id")
 
     def execute(self, context):
-        pmgpanel = context.scene.pmgpanel
-        batoms = pymatgen_search(pmgpanel.key, pmgpanel.id)
+        pymatgen = context.scene.batoms.pymatgen
+        batoms = pymatgen_search(pymatgen.key, pymatgen.id)
         return {'FINISHED'}

--- a/batoms/gui/gui_render.py
+++ b/batoms/gui/gui_render.py
@@ -8,6 +8,8 @@ from bpy.props import (
 )
 from batoms.render.render import Render
 from batoms import Batoms
+from batoms.gui.gui_batoms import get_attr, set_attr
+
 
 class Render_PT_prepare(Panel):
     bl_label = "Render"
@@ -46,210 +48,13 @@ class Render_PT_prepare(Panel):
         row.prop(render, "light_direction_x")
         row.prop(render, "light_direction_y")
         row.prop(render, "light_direction_z")
-        layout.prop(render, "light_energy")
-
-def get_viewport(i):
-    """Helper function to easily get cell-property."""
-
-    def getter(self):
-        render = get_active_render_collection()
-        if render is not None:
-            return render.viewport[i]
-        else:
-            return 0
-    return getter
-
-def set_viewport(i):
-    """Helper function to easily get cell-property."""
-
-    def setter(self, value):
-        render = get_active_render_collection()
-        if render is not None:
-            viewport = render.viewport
-            viewport[i] = value
-            render = get_active_render()
-            render.viewport = viewport
-    return setter
+        layout.prop(render, "energy")
 
 
-
-def get_camera_type(self):
-    camera = get_default_camera()
-    if camera is not None:
-        if camera.data.type == 'ORTHO':
-            return 0
-        else:
-            return 1
-    else:
-        return 0
-
-def set_camera_type(self, value):
-    items = self.bl_rna.properties["camera_type"].enum_items
-    item = items[value]
-    type = item.identifier
-    # print(type)
-    self["type"] = type
-    set_camera_attr('type', type)
-
-def get_lens(self):
-    camera = get_default_camera()
-    if camera is not None:
-        return camera.data.lens
-    else:
-        return 50
-
-def set_lens(self, value):
-    self["lens"] = value
-    set_camera_attr('lens', value)
-
-def get_ortho_scale(self):
-    camera = get_default_camera()
-    if camera is not None:
-        return camera.data.ortho_scale
-    else:
-        return 10
-
-def set_ortho_scale(self, value):
-    self["ortho_scale"] = value
-    set_camera_attr('ortho_scale', value)
-
-def get_distance(self):
-    render = get_active_render_collection()
-    if render is not None:
-        return render.distance
-    else:
-        return 10
-
-def set_distance(self, value):
-    self["distance"] = value
-    render = get_active_render()
-    render.distance = value
-
-def get_light_direction(i):
-    """Helper function to easily get cell-property."""
-
-    def getter(self):
-        light = get_default_light()
-        if light is not None:
-            return light.batoms.light.direction[i]
-        else:
-            return 0
-    return getter
-
-def set_light_direction(i):
-    """Helper function to easily set light-property."""
-
-    def setter(self, value):
-        light = get_default_light()
-        if light is not None:
-            light_direction = light.batoms.light.direction
-            light_direction[i] = value
-            set_light_attr('direction', light_direction)
-    return setter
-
-def get_energy(self):
-    light = get_default_light()
-    if light is not None:
-        return light.data.energy
-    else:
-        return 10
-
-def set_energy(self, value):
-    self["energy"] = value
-    set_light_attr('energy', value)
-
-class RenderProperties(bpy.types.PropertyGroup):
-    """
-    """
-    viewport_x: FloatProperty(
-        name="viewport_x",default=0,
-        soft_min = -5, soft_max = 5,
-        description="Miller viewport for the render",
-        get=get_viewport(0),
-        set=set_viewport(0))
-    
-    viewport_y: FloatProperty(
-        name="viewport_y",default=0,
-        soft_min = -5, soft_max = 5,
-        description="Miller viewport for the render",
-        get=get_viewport(1),
-        set=set_viewport(1))
-    
-    viewport_z: FloatProperty(
-        name="viewport_z",default=1,
-        soft_min = -5, soft_max = 5,
-        description="Miller viewport for the render",
-        get=get_viewport(2),
-        set=set_viewport(2))
-    
-    camera_type: EnumProperty(
-        name="type",
-        description="camera type",
-        items=(('ORTHO', "ORTHO", "", 0),
-               ('PERSP', "PERSP", "", 1)
-               ),
-        default=0,
-        get=get_camera_type,
-        set=set_camera_type,
-    )
-
-    # resolution: IntVectorProperty(
-        # name="resolution", size=2, default=(1000, 1000),
-        # soft_min = 100, soft_max = 2000,
-        # description="Miller resolution for the render", update=Callback_modify_resolution)
-    
-    ortho_scale: FloatProperty(
-        name="ortho_scale", default=10,
-        soft_min = 1, soft_max = 100,
-        description="ortho_scale",
-        get=get_ortho_scale,
-        set=set_ortho_scale)
-
-    light_direction_x: FloatProperty(
-        name="light_direction_x",default=0,
-        soft_min = -5, soft_max = 5,
-        description="Light direction for the render",
-        get=get_light_direction(0),
-        set=set_light_direction(0))
-    
-    light_direction_y: FloatProperty(
-        name="light_direction_y",default=0,
-        soft_min = -5, soft_max = 5,
-        description="Light direction for the render",
-        get=get_light_direction(1),
-        set=set_light_direction(1))
-    
-    light_direction_z: FloatProperty(
-        name="light_direction_z",default=1,
-        soft_min = -5, soft_max = 5,
-        description="Light direction for the render",
-        get=get_light_direction(2),
-        set=set_light_direction(2))
-
-    light_energy: FloatProperty(
-        name="energy", default=10,
-        soft_min = 1, soft_max = 100,
-        description="light_energy",
-        get=get_energy,
-        set=set_energy)
-
-    distance: FloatProperty(
-        name="distance", default=3,
-        description="distance from origin",
-        get=get_distance,
-        set=set_distance)
-
-
-    camera_lens: FloatProperty(
-        name="lens", default=100,
-        soft_min = 1, soft_max = 100,
-        get=get_lens,
-        set=set_lens)
-
-
+# ---------------------------------------------------
 
 def modify_render_attr(context, key, value):
-    
+
     from batoms.batoms import Batoms
     if context.object and context.object.batoms.type != 'OTHER':
         batoms = Batoms(label=context.object.batoms.label)
@@ -275,6 +80,7 @@ def set_light_attr(key, value):
         batoms.render.init()
         bpy.context.space_data.region_3d.view_perspective = 'CAMERA'
 
+
 def set_camera_attr(key, value):
     """Set Camera attribute
 
@@ -296,6 +102,7 @@ def set_camera_attr(key, value):
             batoms.render.init()
         bpy.context.space_data.region_3d.view_perspective = 'CAMERA'
 
+
 def get_active_render_collection():
     """Get the collection of the active Batoms
 
@@ -311,6 +118,7 @@ def get_active_render_collection():
         return bpy.data.collections['batoms_render'].batoms.brender
     return None
 
+
 def get_active_render():
     context = bpy.context
     if 'batoms_render' in bpy.data.collections:
@@ -318,12 +126,203 @@ def get_active_render():
         return render
     return None
 
+
 def get_default_camera():
     if 'batoms_camera_Default' in bpy.data.objects:
         return bpy.data.objects['batoms_camera_Default']
     return None
 
+
+def get_default_camera_data():
+    if 'batoms_camera_Default' in bpy.data.objects:
+        return bpy.data.objects['batoms_camera_Default'].data
+    return None
+
+
 def get_default_light():
     if 'batoms_light_Default' in bpy.data.objects:
         return bpy.data.objects['batoms_light_Default']
     return None
+
+
+def get_default_light_dat():
+    if 'batoms_light_Default' in bpy.data.objects:
+        return bpy.data.objects['batoms_light_Default'].data
+    return None
+
+
+def get_viewport(i):
+    """Helper function to easily get cell-property."""
+
+    def getter(self):
+        render = get_active_render_collection()
+        if render is not None:
+            return render.viewport[i]
+        else:
+            return 0
+    return getter
+
+
+def set_viewport(i):
+    """Helper function to easily get cell-property."""
+
+    def setter(self, value):
+        render = get_active_render_collection()
+        if render is not None:
+            viewport = render.viewport
+            viewport[i] = value
+            render = get_active_render()
+            render.viewport = viewport
+    return setter
+
+
+def get_camera_type(self):
+    camera = get_default_camera()
+    if camera is not None:
+        if camera.data.type == 'ORTHO':
+            return 0
+        else:
+            return 1
+    else:
+        return 0
+
+
+def set_camera_type(self, value):
+    items = self.bl_rna.properties["camera_type"].enum_items
+    item = items[value]
+    type = item.identifier
+    # print(type)
+    self["type"] = type
+    set_camera_attr('type', type)
+
+
+def get_distance(self):
+    render = get_active_render_collection()
+    if render is not None:
+        return render.distance
+    else:
+        return 10
+
+
+def set_distance(self, value):
+    self["distance"] = value
+    render = get_active_render()
+    render.distance = value
+
+
+def get_light_direction(i):
+    """Helper function to easily get cell-property."""
+
+    def getter(self):
+        light = get_default_light()
+        if light is not None:
+            return light.batoms.light.direction[i]
+        else:
+            return 0
+    return getter
+
+
+def set_light_direction(i):
+    """Helper function to easily set light-property."""
+
+    def setter(self, value):
+        light = get_default_light()
+        if light is not None:
+            light_direction = light.batoms.light.direction
+            light_direction[i] = value
+            set_light_attr('direction', light_direction)
+    return setter
+
+
+class RenderProperties(bpy.types.PropertyGroup):
+    """
+    """
+    viewport_x: FloatProperty(
+        name="viewport_x", default=0,
+        soft_min=-5, soft_max=5,
+        description="Miller viewport for the render",
+        get=get_viewport(0),
+        set=set_viewport(0))
+
+    viewport_y: FloatProperty(
+        name="viewport_y", default=0,
+        soft_min=-5, soft_max=5,
+        description="Miller viewport for the render",
+        get=get_viewport(1),
+        set=set_viewport(1))
+
+    viewport_z: FloatProperty(
+        name="viewport_z", default=1,
+        soft_min=-5, soft_max=5,
+        description="Miller viewport for the render",
+        get=get_viewport(2),
+        set=set_viewport(2))
+
+    camera_type: EnumProperty(
+        name="type",
+        description="camera type",
+        items=(('ORTHO', "ORTHO", "", 0),
+               ('PERSP', "PERSP", "", 1)
+               ),
+        default=0,
+        get=get_camera_type,
+        set=set_camera_type,
+    )
+
+    # resolution: IntVectorProperty(
+    # name="resolution", size=2, default=(1000, 1000),
+    # soft_min = 100, soft_max = 2000,
+    # description="Miller resolution for the render", update=Callback_modify_resolution)
+
+    ortho_scale: FloatProperty(
+        name="ortho_scale", default=10,
+        soft_min=1, soft_max=100,
+        description="ortho_scale",
+        get=get_attr("ortho_scale", get_default_camera_data),
+        set=set_attr("ortho_scale", set_camera_attr)
+    )
+
+    light_direction_x: FloatProperty(
+        name="light_direction_x", default=0,
+        soft_min=-5, soft_max=5,
+        description="Light direction for the render",
+        get=get_light_direction(0),
+        set=set_light_direction(0)
+    )
+
+    light_direction_y: FloatProperty(
+        name="light_direction_y", default=0,
+        soft_min=-5, soft_max=5,
+        description="Light direction for the render",
+        get=get_light_direction(1),
+        set=set_light_direction(1)
+    )
+
+    light_direction_z: FloatProperty(
+        name="light_direction_z", default=1,
+        soft_min=-5, soft_max=5,
+        description="Light direction for the render",
+        get=get_light_direction(2),
+        set=set_light_direction(2)
+    )
+
+    energy: FloatProperty(
+        name="energy", default=10,
+        soft_min=1, soft_max=100,
+        description="energy",
+        get=get_attr("energy", get_default_light_dat),
+        set=set_attr("energy", set_light_attr)
+    )
+
+    distance: FloatProperty(
+        name="distance", default=3,
+        description="distance from origin",
+        get=get_distance,
+        set=set_distance)
+
+    camera_lens: FloatProperty(
+        name="lens", default=100,
+        soft_min=1, soft_max=100,
+        get=get_attr("lens", get_default_camera_data),
+        set=set_attr("lens", set_camera_attr)
+    )

--- a/batoms/gui/gui_render.py
+++ b/batoms/gui/gui_render.py
@@ -19,34 +19,34 @@ class Render_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        repanel = context.scene.repanel
+        render = context.scene.batoms.render
 
         layout = self.layout
         # row = col.row(align=True)
         layout.operator("batoms.render_add")
         layout.label(text="Viewport")
         row = layout.row()
-        row.prop(repanel, "viewport_x")
-        row.prop(repanel, "viewport_y")
-        row.prop(repanel, "viewport_z")
+        row.prop(render, "viewport_x")
+        row.prop(render, "viewport_y")
+        row.prop(render, "viewport_z")
         layout.separator()
         # col = layout.column()
         layout.label(text="Camera")
         layout.label(text="Type")
-        layout.prop(repanel, "camera_type", expand=True)
-        if repanel.camera_type == 'ORTHO':
-            layout.prop(repanel, "ortho_scale")
+        layout.prop(render, "camera_type", expand=True)
+        if render.camera_type == 'ORTHO':
+            layout.prop(render, "ortho_scale")
         else:
-            layout.prop(repanel, "camera_lens")
-            layout.prop(repanel, "distance")
-        # layout.prop(repanel, "resolution")
+            layout.prop(render, "camera_lens")
+            layout.prop(render, "distance")
+        # layout.prop(render, "resolution")
         layout.separator()
         layout.label(text="Light")
         row = layout.row()
-        row.prop(repanel, "light_direction_x")
-        row.prop(repanel, "light_direction_y")
-        row.prop(repanel, "light_direction_z")
-        layout.prop(repanel, "light_energy")
+        row.prop(render, "light_direction_x")
+        row.prop(render, "light_direction_y")
+        row.prop(render, "light_direction_z")
+        layout.prop(render, "light_energy")
 
 def get_viewport(i):
     """Helper function to easily get cell-property."""

--- a/batoms/gui/gui_rscb.py
+++ b/batoms/gui/gui_rscb.py
@@ -17,10 +17,10 @@ class RSCB_PT_prepare(Panel):
 
     def draw(self, context):
         layout = self.layout
-        pubcpanel = context.scene.pubcpanel
+        rscb = context.scene.batoms.rscb
 
         layout.label(text="Import PDB")
-        layout.prop(pubcpanel, "name")
+        layout.prop(rscb, "name")
         layout.operator("batoms.rscb_import")
 
 
@@ -37,7 +37,7 @@ class RSCB_Import(Operator):
     bl_description = ("Import pdb by name")
 
     def execute(self, context):
-        pubcpanel = context.scene.pubcpanel
-        batoms = rscb_import(pubcpanel.name)
+        rscb = context.scene.batoms.rscb
+        batoms = rscb_import(rscb.name)
         batoms.ribbon.draw()
         return {'FINISHED'}

--- a/batoms/ops/ops_batoms.py
+++ b/batoms/ops/ops_batoms.py
@@ -10,7 +10,7 @@ from bpy.props import (
 )
 from batoms import Batoms
 from batoms.ops.base import OperatorBatoms, OperatorBatomsEdit
-from batoms.utils.butils import get_selected_vertices_bmesh
+from batoms.utils.butils import get_selected_vertices
 
 class BatomsReplace(OperatorBatomsEdit):
     bl_idname = "batoms.replace"
@@ -23,7 +23,7 @@ class BatomsReplace(OperatorBatomsEdit):
 
     def execute(self, context):
         obj = context.object
-        v = get_selected_vertices_bmesh(obj)
+        v = get_selected_vertices(obj)
         batoms = Batoms(label=obj.batoms.label)
         batoms.replace(v, self.species)
         bpy.ops.object.mode_set(mode='EDIT')
@@ -37,7 +37,7 @@ class BatomModify(OperatorBatomsEdit):
     bl_description = ("Modify batom")
 
     key: StringProperty(
-        name="key", default='style',
+        name="key", default='scale',
         description="Replaced by this species")
 
     scale: FloatProperty(name="scale", default=0.6,
@@ -59,7 +59,7 @@ class BatomModify(OperatorBatomsEdit):
 
     def execute(self, context):
         obj = context.object
-        v = get_selected_vertices_bmesh(obj)
+        v = get_selected_vertices(obj)
         batoms = Batoms(label=obj.batoms.label)
         for i in v:
             setattr(batoms[i], self.key, getattr(self, self.key))

--- a/batoms/utils/butils.py
+++ b/batoms/utils/butils.py
@@ -9,6 +9,9 @@ logger = logging.getLogger(__name__)
 def get_selected_vertices_bmesh(obj):
     """_summary_
 
+    Warnning: bmesh.select_history does not support
+     box/lasso/circle/other selected vertices.
+
     Args:
         obj (bpy.type.object): _description_
 
@@ -85,8 +88,25 @@ def get_selected_objects(attr):
             objs.append(obj.name)
     return objs
 
+def get_selected_vertices(obj):
+    """
+    """
+    import numpy as np
+    selected_vertices = []
+    # if obj.mode != "EDIT":
+        # logger.warning('Warning: Please switch to Edit mode.')
+        # return selected_vertices
+    mode = obj.mode
+    bpy.ops.object.mode_set(mode='OBJECT')
+    count = len(obj.data.vertices)
+    sel = np.zeros(count, dtype=np.bool)
+    obj.data.vertices.foreach_get('select', sel)
+    selected_vertices = np.where(sel)[0]
+    # back to whatever mode we were in
+    bpy.ops.object.mode_set(mode=mode)
+    return selected_vertices.tolist()
 
-def get_selected_vertices():
+def get_selected_vertices_all():
     """
     change to 'Object' mode
     in order

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -67,8 +67,8 @@ def test_render():
     ch4.render.lights["Default"].direction = [1, 0, 0]
     assert np.isclose(bpy.context.scene.batoms.render.light_direction_x, 1)
     ch4.render.lights["Default"].energy = 20
-    assert np.isclose(bpy.context.scene.batoms.render.light_energy, 20)
-    # bpy.context.scene.batoms.render.light_energy = 5
+    assert np.isclose(bpy.context.scene.batoms.render.energy, 20)
+    # bpy.context.scene.batoms.render.energy = 5
     # assert np.isclose(ch4.render.lights["Default"].energy, 5)
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -5,6 +5,7 @@ import pytest
 
 def test_batoms():
     """Batoms panel"""
+    from batoms.batoms import Batoms
     bpy.ops.batoms.delete()
     bpy.ops.batoms.molecule_add()
     ch4 = Batoms('CH4')
@@ -28,6 +29,7 @@ def test_batoms():
 
 def test_cell():
     """Cell panel"""
+    from batoms.batoms import Batoms
     bpy.ops.batoms.delete()
     bpy.ops.batoms.molecule_add()
     ch4 = Batoms('CH4')
@@ -40,6 +42,7 @@ def test_cell():
 
 def test_render():
     """Render panel"""
+    from batoms.batoms import Batoms
     bpy.ops.batoms.delete()
     bpy.ops.batoms.molecule_add()
     ch4 = Batoms('CH4')
@@ -71,9 +74,40 @@ def test_render():
     # bpy.context.scene.batoms.render.energy = 5
     # assert np.isclose(ch4.render.lights["Default"].energy, 5)
 
+def test_batom():
+    """Batom panel"""
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.molecule_add()
+    ch4 = Batoms('CH4')
+    ch4.obj.select_set(True)
+    # scale
+    assert np.isclose(bpy.context.scene.batoms.batom.scale, ch4[0].scale)
+    bpy.context.scene.batoms.batom.scale = 1
+    assert np.isclose(ch4[0].scale, bpy.context.scene.batoms.batom.scale)
+
+def test_bond():
+    """Bond panel"""
+    from batoms.batoms import Batoms
+    import numpy as np
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.molecule_add()
+    ch4 = Batoms('CH4')
+    ch4.bonds.obj.data.vertices.foreach_set('select', [1, 0, 0, 0, 0])
+    ch4.bonds[0].order = 2
+    # order
+    ch4.obj.select_set(False)
+    bpy.context.view_layer.objects.active = ch4.bonds.obj
+    assert np.isclose(bpy.context.scene.batoms.bond.order, ch4.bonds[0].order)
+    ch4.bonds.obj.data.vertices.foreach_set('select', [1, 0, 0, 0])
+    bpy.context.scene.batoms.bond.order = 1
+    assert np.isclose(ch4.bonds[0].order, bpy.context.scene.batoms.bond.order)
+
 
 if __name__ == "__main__":
     test_batoms()
     test_cell()
     test_render()
+    test_batom()
+    test_bond()
     print("\n GUI: All pass! \n")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -10,20 +10,20 @@ def test_batoms():
     ch4 = Batoms('CH4')
     ch4.obj.select_set(True)
     # model_style
-    assert bpy.context.scene.bapanel.model_style.upper() == "BALL-AND-STICK"
-    bpy.context.scene.bapanel.model_style = "Space-filling"
+    assert bpy.context.scene.batoms.batoms.model_style.upper() == "BALL-AND-STICK"
+    bpy.context.scene.batoms.batoms.model_style = "Space-filling"
     assert ch4.model_style[0] == 0
     # radius_style
-    assert bpy.context.scene.bapanel.radius_style.upper() == "COVALENT"
-    bpy.context.scene.bapanel.radius_style = "VDW"
+    assert bpy.context.scene.batoms.batoms.radius_style.upper() == "COVALENT"
+    bpy.context.scene.batoms.batoms.radius_style = "VDW"
     assert ch4.radius_style == '1'
     # color_style
-    assert bpy.context.scene.bapanel.color_style.upper() == "JMOL"
-    bpy.context.scene.bapanel.color_style = "CPK"
+    assert bpy.context.scene.batoms.batoms.color_style.upper() == "JMOL"
+    bpy.context.scene.batoms.batoms.color_style = "CPK"
     assert ch4.color_style == '2'
     # show
-    assert bpy.context.scene.bapanel.show == True
-    bpy.context.scene.bapanel.show = False
+    assert bpy.context.scene.batoms.batoms.show == True
+    bpy.context.scene.batoms.batoms.show = False
     assert ch4.show[0] == False
 
 def test_cell():
@@ -34,8 +34,8 @@ def test_cell():
     ch4.cell = [1, 2, 3]
     ch4.obj.select_set(True)
     # model_style
-    assert np.isclose(bpy.context.scene.clpanel.cell_a0, 1)
-    bpy.context.scene.clpanel.cell_a0 = 3
+    assert np.isclose(bpy.context.scene.batoms.cell.cell_a0, 1)
+    bpy.context.scene.batoms.cell.cell_a0 = 3
     assert np.isclose(ch4.cell[0, 0], 3)
 
 def test_render():
@@ -50,25 +50,25 @@ def test_render():
     assert ch4._render is not None
     # viewport
     ch4.render.viewport = [1, 0, 0]
-    assert np.isclose(bpy.context.scene.repanel.viewport_x, 1)
-    bpy.context.scene.repanel.viewport_y = 2
+    assert np.isclose(bpy.context.scene.batoms.render.viewport_x, 1)
+    bpy.context.scene.batoms.render.viewport_y = 2
     assert ch4.render.viewport[1] == 2
     # camera
     ch4.render.camera.type = "ORTHO"
-    assert bpy.context.scene.repanel.camera_type == "ORTHO"
+    assert bpy.context.scene.batoms.render.camera_type == "ORTHO"
     # Some GUI tests can only be tested manually by opening Blender
-    # bpy.context.scene.repanel.camera_type = "PERSP"
+    # bpy.context.scene.batoms.render.camera_type = "PERSP"
     # assert ch4.render.camera.type == 'PERSP'
     ch4.render.camera.ortho_scale = 20
-    assert np.isclose(bpy.context.scene.repanel.ortho_scale, 20)
-    # bpy.context.scene.repanel.ortho_scale = 5
+    assert np.isclose(bpy.context.scene.batoms.render.ortho_scale, 20)
+    # bpy.context.scene.batoms.render.ortho_scale = 5
     # assert np.isclose(ch4.render.camera.ortho_scale, 5)
     # light
     ch4.render.lights["Default"].direction = [1, 0, 0]
-    assert np.isclose(bpy.context.scene.repanel.light_direction_x, 1)
+    assert np.isclose(bpy.context.scene.batoms.render.light_direction_x, 1)
     ch4.render.lights["Default"].energy = 20
-    assert np.isclose(bpy.context.scene.repanel.light_energy, 20)
-    # bpy.context.scene.repanel.light_energy = 5
+    assert np.isclose(bpy.context.scene.batoms.render.light_energy, 20)
+    # bpy.context.scene.batoms.render.light_energy = 5
     # assert np.isclose(ch4.render.lights["Default"].energy, 5)
 
 


### PR DESCRIPTION
Clean code
-----------------------
The code in GUI is very messy. Try to fix this by:

- use one BatomsCollection for all panel properties
- update GUI properties using the helper function

Get/set properties in Edit mode
------------------------------------------

Two methods can be used:
- switch the object to `Object` mode, read the attribute directly, then switch back to 'Edit' mode. 
- use `bmesh.from_edit_mesh` method to get/set data for Batom in EDIT mode. Bmesh method can only be used for int, float and string attributes. 

Time (s) used to set and get attributes 

|Number of vertices | switch mode | bmesh | 
|---|---|---|
|  4  |     0.003   |    0.00005    | 
| 500    |     0.005    |   0.0002     | 
|   4000 |     0.01   |  0.001   |
|   32000 |     0.09   |  0.01   |

We will use bmesh for int, float and string, and switch mode method for others.
