### PR TITLE
attach node_group manully for Blender 3.2

### DIFF
--- a/batoms/base/object.py
+++ b/batoms/base/object.py
@@ -273,9 +273,9 @@ class ObjectGN(BaseObject):
         """
         Geometry node for everything!
         """
+        from batoms.utils.butils import build_modifier
         name = 'GeometryNodes_%s' % self.obj_name
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
 
     def vectorDotMatrix(self, gn, vectorNode, matrix, name):
         """

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -257,9 +257,9 @@ class Batoms(BaseCollection, ObjectGN):
     def build_geometry_node(self):
         """Geometry node for instancing sphere on vertices!
         """
+        from batoms.utils.butils import build_modifier
         name = 'GeometryNodes_%s' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]
         GroupOutput = modifier.node_group.nodes[1]

--- a/batoms/bond/__init__.py
+++ b/batoms/bond/__init__.py
@@ -189,12 +189,12 @@ class Bonds(BaseCollection, ObjectGN):
         """
         todo: add width to nodes
         """
-        from batoms.utils.butils import get_nodes_by_name
+        from batoms.utils.butils import get_nodes_by_name, compareNodeType, \
+                            build_modifier
         from batoms.utils import string2Number
         tstart = time()
         name = 'GeometryNodes_%s_bond' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]

--- a/batoms/bond/bondsetting.py
+++ b/batoms/bond/bondsetting.py
@@ -305,7 +305,7 @@ class BondSettings(Setting):
         nv = len(obj.data.vertices)
         for i in range(nv):
             obj.data.vertices[i].co[0] -= 2*(order - 1)*radius
-        bpy.ops.object.modifier_apply(modifier='Array')
+        # bpy.ops.object.modifier_apply(modifier='Array')
         #
         if style == 2:
             mod = obj.modifiers.new('arrayStyle', 'ARRAY')
@@ -314,7 +314,7 @@ class BondSettings(Setting):
             nv = len(obj.data.vertices)
             for i in range(nv):
                 obj.data.vertices[i].co[2] -= (10 - 1)*depth
-        bpy.ops.object.modifier_apply(modifier='Array')
+        # bpy.ops.object.modifier_apply(modifier='Array')
         obj.name = name
         obj.data.name = name
         return obj

--- a/batoms/bond/search_bond.py
+++ b/batoms/bond/search_bond.py
@@ -129,10 +129,9 @@ class SearchBond(ObjectGN):
     def build_geometry_node(self):
         """
         """
-        from batoms.utils.butils import get_nodes_by_name
+        from batoms.utils.butils import get_nodes_by_name, build_modifier
         name = 'GeometryNodes_%s_search_bond' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -207,10 +207,9 @@ class Boundary(ObjectGN):
     def build_geometry_node(self):
         """
         """
-        from batoms.utils.butils import get_nodes_by_name
+        from batoms.utils.butils import get_nodes_by_name, build_modifier
         name = 'GeometryNodes_%s_boundary' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]

--- a/batoms/cavity/__init__.py
+++ b/batoms/cavity/__init__.py
@@ -329,9 +329,9 @@ class Cavity(ObjectGN):
     def build_geometry_node(self):
         """Geometry node for instancing sphere on vertices!
         """
+        from batoms.utils.butils import build_modifier
         name = 'GeometryNodes_%s' % self.obj_name
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]
         GroupOutput = modifier.node_group.nodes[1]

--- a/batoms/cell.py
+++ b/batoms/cell.py
@@ -80,10 +80,10 @@ class Bcell(ObjectGN):
     def build_geometry_node(self):
         """
         """
-        from batoms.utils.butils import get_nodes_by_name, compareNodeType
+        from batoms.utils.butils import get_nodes_by_name, compareNodeType, \
+                            build_modifier
         name = 'GeometryNodes_%s_cell' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         # ------------------------------------------------------------------
         # select attributes
         gn = modifier

--- a/batoms/polyhedra/__init__.py
+++ b/batoms/polyhedra/__init__.py
@@ -178,11 +178,10 @@ class Polyhedras(ObjectGN):
         """
         Geometry node for everything!
         """
-        from batoms.utils.butils import get_nodes_by_name
+        from batoms.utils.butils import get_nodes_by_name, build_modifier
         tstart = time()
         name = 'GeometryNodes_%s_polyhedra' % self.label
-        modifier = self.obj.modifiers.new(name=name, type='NODES')
-        modifier.node_group.name = name
+        modifier = build_modifier(self.obj, name)
         # ------------------------------------------------------------------
         inputs = modifier.node_group.inputs
         GroupInput = modifier.node_group.nodes[0]

--- a/batoms/utils/butils.py
+++ b/batoms/utils/butils.py
@@ -363,7 +363,17 @@ def hideOneLevel():
         bpy.ops.outliner.show_one_level(c, open=False)
         ol.tag_redraw()
 
-
+def build_modifier(obj, name):
+    from bl_operators.geometry_nodes import geometry_node_group_empty_new
+    modifier = obj.modifiers.new(name=name, type='NODES')
+    if bpy.app.version_string >= '3.2.0':
+        # bpy.context.view_layer.objects.active = obj
+        # bpy.context.object.modifiers.active = modifier
+        # bpy.ops.node.new_geometry_node_group_assign()
+        group = geometry_node_group_empty_new()
+        modifier.node_group = group
+    modifier.node_group.name = name
+    return modifier
 # ========================================================
 if bpy.app.version_string >= '3.1.0':
     compareNodeType = 'FunctionNodeCompare'


### PR DESCRIPTION
Solution for  #128 .
In Blender 3.2, we have to `Create a new geometry node group and assign it to the modifier`.

The following code is added.
```python
if bpy.app.version_string >= '3.2.0':
    group = geometry_node_group_empty_new()
    modifier.node_group = group
```

@alchem0x2A Please add docker and test support for Blender 3.2.
