### PR TITLE
Update actions to add version tags in container images

### DIFF
--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -35,7 +35,6 @@ jobs:
           echo ${{ steps.tagName.outputs }}
           echo ${{ env.GIT_TAG_NAME }}
           echo Current tag is ${{ env.GIT_TAG_NAME }}
-          echo Is tag ok to add to docker tag? ${{ startsWith(env.GIT_TAG_NAME, 'v') }}
           echo "ADD_VERSION_DOCKER=${{ startsWith(env.GIT_TAG_NAME, 'v') }}" >> ${GITHUB_ENV}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Test tagger
         run:
           echo Current tag is ${{ env.GIT_TAG_NAME }}
-          echo Is tag ok to add to docker tag? ${{ startsWith(env.GIT_TAG_NAME, "v") }}
+          echo Is tag ok to add to docker tag? ${{ startsWith(env.GIT_TAG_NAME, 'v') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -31,10 +31,12 @@ jobs:
           tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
       # Add special release tag if tag exists
       - name: Test tagger
-        run:
+        run: |
           echo ${{ steps.tagName.outputs }}
           echo ${{ env.GIT_TAG_NAME }}
           echo Current tag is ${{ env.GIT_TAG_NAME }}
+      - name: Pass Tagger Flag
+        run: |
           echo "ADD_VERSION_DOCKER=${{ startsWith(env.GIT_TAG_NAME, 'v') }}" >> ${GITHUB_ENV}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -27,11 +27,12 @@ jobs:
       - name: Get Tag
         uses: olegtarasov/get-tag@v2.1
         id: tagName
-        # with:
-          # tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
+        with:
+          tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
       - name: Echo tag Name
         run: |
           echo ${{ steps.tagName.outputs }}
+          echo ${{ env.GIT_TAG_NAME }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -29,15 +29,14 @@ jobs:
         id: tagName
         with:
           tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
-      - name: Echo tag Name
-        run: |
-          echo ${{ steps.tagName.outputs }}
-          echo ${{ env.GIT_TAG_NAME }}
       # Add special release tag if tag exists
       - name: Test tagger
         run:
+          echo ${{ steps.tagName.outputs }}
+          echo ${{ env.GIT_TAG_NAME }}
           echo Current tag is ${{ env.GIT_TAG_NAME }}
           echo Is tag ok to add to docker tag? ${{ startsWith(env.GIT_TAG_NAME, 'v') }}
+          echo "ADD_VERSION_DOCKER=${{ startsWith(env.GIT_TAG_NAME, 'v') }}" >> ${GITHUB_ENV}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx
@@ -101,3 +100,11 @@ jobs:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}
+      - name: Make version-tagged images
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}
+          dst: |
+            docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
+            ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
+        if: ${{ env.ADD_VERSION_DOCKER }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Get Tag
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+        with:
+          tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
+      - name: Echo tag Name
+        run: |
+          echo ${{ steps.tagName.outputs.tag }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           echo ${{ steps.tagName.outputs }}
           echo ${{ env.GIT_TAG_NAME }}
+      # Add special release tag if tag exists
+      - name: Test tagger
+        run:
+          echo Current tag is ${{ env.GIT_TAG_NAME }}
+          echo Is tag ok to add to docker tag? ${{ startsWith(env.GIT_TAG_NAME, "v") }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Get Tag
         uses: olegtarasov/get-tag@v2.1
         id: tagName
-        with:
-          tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
+        # with:
+          # tagRegex: "(v\\d+\\.\\d+\\.\\d+.*)"
       - name: Echo tag Name
         run: |
-          echo ${{ steps.tagName.outputs.tag }}
+          echo ${{ steps.tagName.outputs }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: setup docker context for buildx


### PR DESCRIPTION
Allow build main image action to append specific version tag to the container image, e.g. `docker pull ghcr.io/beautiful-atoms/beautiful-atoms:blender3.1-v2.1.0b6` based on tag `v2.1.0b6` (commit `a15b81a2`). Once a new tag is pushed to the main branch, the action will automatically create such container tags. Manual execution of the action based on specific tag is also possible.

Complete 1 TODO in https://github.com/beautiful-atoms/beautiful-atoms/issues/123