### PR TITLE
Fix bug in container image tagging

### DIFF
--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -108,4 +108,4 @@ jobs:
           dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
-        if: ${{ env.ADD_VERSION_DOCKER }}
+        if: ${{ env.ADD_VERSION_DOCKER == 'false' }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -101,7 +101,7 @@ jobs:
           src: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}
           dst: docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:latest
         if: ${{ matrix.blender-version == env.LATEST_VERSION }}
-      - name: Make version-tagged images
+      - name: Make version-tagged images only if there is a git tag in format 'vX.Y.Zetc'
         uses: akhilerm/tag-push-action@v2.0.0
         with:
           src: ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -108,4 +108,4 @@ jobs:
           dst: |
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
             ghcr.io/${{ env.REPO_OWNER_LC }}/${{ env.IMAGE_NAME }}:blender${{ matrix.blender-version }}-${{ env.GIT_TAG_NAME }}
-        if: ${{ env.ADD_VERSION_DOCKER == 'false' }}
+        if: ${{ env.ADD_VERSION_DOCKER == 'true' }}


### PR DESCRIPTION
Github actions seems to have `true` and `false` handled as string values. Change comparison condition to avoid unwanted tagging