### PR TITLE
fix model_style and scale

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -63,13 +63,11 @@ class Batoms(BaseCollection, ObjectGN):
                  show_unit_cell=True,
                  scale=1.0,
                  model_style=0,
-                 polyhedra_style=0,
                  radius_style='0',
                  color_style='0',
                  from_ase=None,
                  from_pymatgen=None,
                  from_pybel=None,
-                 metaball=False,
                  movie=True,
                  segments=None,
                  ):
@@ -108,8 +106,6 @@ class Batoms(BaseCollection, ObjectGN):
                 Scale factor for all atoms. Defaults to 1.0.
             model_style (int, optional):
                 Enum in [0, 1, 2, 3]. Defaults to 0.
-            polyhedra_style (int, optional):
-                Enum in [0, 1, 2]. Defaults to 0.
             from_ase (ASE Atoms, optional):
                 Import structure from ASE. Defaults to None.
             from_pymatgen (Pymatgen structure, optional):
@@ -152,18 +148,16 @@ class Batoms(BaseCollection, ObjectGN):
                 positions = self._frames["positions"][0]
             else:
                 self._frames = {"positions": np.array([positions])}
-            #
+            # init attributes
             natom = len(positions)
-            if isinstance(scale, (int, float)):
-                scale = np.ones(natom)*scale
-            show = np.ones(natom, dtype=int)
-            species_index = [string2Number(sp) for sp in species]
+            self.coll.batoms.scale = scale
+            self.coll.batoms.model_style = str(model_style)
             arrays = {
                       'species': species,
-                      'species_index': species_index,
-                      'scale': scale,
-                      'show': show,
-                      'model_style': np.zeros(natom, dtype=int),
+                      'species_index': [string2Number(sp) for sp in species],
+                      'scale': np.ones(natom)*scale,
+                      'show': np.ones(natom, dtype=int),
+                      'model_style': np.ones(natom, dtype=int)*model_style,
                       'select': np.zeros(natom, dtype=int),
                       }
             if attributes is not None:
@@ -518,23 +512,19 @@ class Batoms(BaseCollection, ObjectGN):
         self.set_scale(scale)
 
     def get_scale(self):
-        scale = self.attributes['scale']
+        # scale = self.attributes['scale']
+        scale = self.coll.batoms.scale
         return scale
 
     def set_scale(self, scale):
         """
         """
-        if isinstance(scale, (int, float)):
-            scale = np.ones(len(self))*scale
-        # for species
-        elif isinstance(scale, dict):
-            species = self.attributes['species']
-            scale0 = self.scale
-            for key, value in scale.items():
-                scale0[np.where(species == key)] = value
-            scale = scale0
-        self.set_attributes({'scale': scale})
-        self.coll.batoms.scale = scale[0]
+        self.coll.batoms.scale = scale
+        scale_array = np.ones(len(self))*scale
+        self.set_scale_array(scale_array)
+
+    def set_scale_array(self, scale_array):
+        self.set_attributes({'scale': scale_array})
 
 
     @property
@@ -572,7 +562,7 @@ class Batoms(BaseCollection, ObjectGN):
         self.set_model_style(model_style)
 
     def get_model_style(self):
-        return self.attributes['model_style']
+        return int(self.coll.batoms.model_style)
 
     def set_model_style(self, model_style):
         self.coll.batoms.model_style = str(model_style)

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -569,6 +569,14 @@ class Batoms(BaseCollection, ObjectGN):
         model_style_array = np.ones(len(self), dtype=int)*int(model_style)
         self.set_model_style_array(model_style_array)
 
+    @property
+    def model_style_array(self):
+        return self.get_attribute('model_style')
+
+    @model_style_array.setter
+    def model_style_array(self, model_style_array):
+        self.set_model_style_array(model_style_array)
+
     def set_model_style_array(self, model_style_array):
         model_style = {'model_style': model_style_array}
         self.set_attributes(model_style)
@@ -1677,11 +1685,11 @@ class Batoms(BaseCollection, ObjectGN):
         self.draw_wireframe()
 
     def draw_space_filling(self, scale=1.0):
-        mask = np.where(self.model_style == 0, True, False)
+        mask = np.where(self.model_style_array == 0, True, False)
         self.set_attribute_with_indices('scale', mask, scale)
 
     def draw_ball_and_stick(self, scale=0.4):
-        mask = np.where(self.model_style >= 1, True, False)
+        mask = np.where(self.model_style_array >= 1, True, False)
         if not mask.any():
             from batoms.bond import default_bond_datas
             self.bonds.set_arrays(default_bond_datas.copy())
@@ -1691,7 +1699,7 @@ class Batoms(BaseCollection, ObjectGN):
         self.bonds.update()
 
     def draw_polyhedra(self, scale=0.4):
-        mask = np.where(self.model_style == 2, True, False)
+        mask = np.where(self.model_style_array == 2, True, False)
         if not mask.any():
             from batoms.polyhedra import default_polyhedra_datas
             self.polyhedras.set_arrays(default_polyhedra_datas)
@@ -1732,7 +1740,7 @@ class Batoms(BaseCollection, ObjectGN):
             # self.set_attribute_with_indices('show', mask, False)
 
     def draw_wireframe(self):
-        mask = np.where(self.model_style == 3, True, False)
+        mask = np.where(self.model_style_array == 3, True, False)
         # self.set_attribute_with_indices('show', mask, 0)
         self.set_attribute_with_indices('scale', mask, 0.0001)
         # self.update(mask)

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -56,6 +56,19 @@ def test_batoms_crystal():
     assert au.pbc == [True, True, True]
     assert np.isclose(au.cell[0, 0], a)
 
+def test_batoms_parameters():
+    """Create a Batoms object from scratch"""
+    bpy.ops.batoms.delete()
+    from batoms import Batoms
+    h2o = Batoms(
+        "h2o",
+        species=["O", "H", "H"],
+        positions=[[0, 0, 0.40], [0, -0.76, -0.2], [0, 0.76, -0.2]],
+        model_style=1,
+        scale=0.5,
+    )
+    assert h2o.model_style == 1
+    assert np.isclose(h2o.scale, 0.5)
 
 def test_batoms_species():
     """Setting properties of species"""
@@ -216,7 +229,7 @@ def test_set_arrays():
     )
     h2o.show = [1, 0, 1]
     assert not h2o[1].show
-    h2o.scale = [1, 1, 1]
+    h2o.scale = 1
     h2o.set_attributes({"scale": np.array([0.3, 0.3, 0.3])})
     # attributes
     h2o.show = 1

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -18,7 +18,7 @@ def test_boundary_scale():
     au = Batoms("au", from_ase=bulk("Au", cubic=True))
     au.scale = 0.5
     au.boundary = [1, 1, 1]
-    assert np.allclose(au.scale[0], 0.5)
+    assert np.allclose(au.boundary.get_attribute('scale')[0], 0.5)
     # repeat
 
 def test_boundary_off_origin():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -13,7 +13,7 @@ def test_batoms():
     # model_style
     assert bpy.context.scene.batoms.batoms.model_style.upper() == "BALL-AND-STICK"
     bpy.context.scene.batoms.batoms.model_style = "Space-filling"
-    assert ch4.model_style[0] == 0
+    assert ch4.model_style == 0
     # radius_style
     assert bpy.context.scene.batoms.batoms.radius_style.upper() == "COVALENT"
     bpy.context.scene.batoms.batoms.radius_style = "VDW"

--- a/tests/test_ops_batoms.py
+++ b/tests/test_ops_batoms.py
@@ -158,6 +158,7 @@ def test_ase_surface():
 # Below for edit mode
 #==============================================
 def test_batoms_apply_model_style_selected():
+    import numpy as np
     from batoms import Batoms
     bpy.ops.batoms.delete()
     bpy.ops.batoms.molecule_add(label="nh3", formula="NH3")
@@ -165,6 +166,7 @@ def test_batoms_apply_model_style_selected():
     nh3 = Batoms('nh3')
     au111 = Batoms('au111')
     au111 += nh3
+    au111.model_style = 0
     bpy.context.view_layer.objects.active = au111.obj
     # only select nh3
     au111.obj.data.vertices.foreach_set('select', [0, 0, 0, 0, 1, 1, 1, 1])
@@ -172,6 +174,8 @@ def test_batoms_apply_model_style_selected():
     bpy.ops.batoms.apply_model_style_selected(model_style='1')
     assert au111.get_attribute('model_style')[0] == 0
     assert au111.get_attribute('model_style')[-1] == 1
+    assert np.isclose(au111.get_attribute('scale')[0], 1)
+    assert np.isclose(au111.get_attribute('scale')[-1], 0.4)
 
 
 if __name__ == "__main__":

--- a/tests/test_ops_batoms.py
+++ b/tests/test_ops_batoms.py
@@ -34,10 +34,10 @@ def test_batoms_apply_model_style():
     bpy.ops.batoms.delete()
     bpy.ops.batoms.molecule_add(label="nh3", formula="NH3")
     nh3 = Batoms('nh3')
-    assert nh3.model_style[0] == 1
+    assert nh3.model_style == 1
     # model_style
     bpy.ops.batoms.apply_model_style(model_style='0')
-    assert nh3.model_style[0] == 0
+    assert nh3.model_style == 0
     # radius_style
     bpy.ops.batoms.apply_radius_style(radius_style='1')
     assert nh3.radius_style == '1'
@@ -170,8 +170,8 @@ def test_batoms_apply_model_style_selected():
     au111.obj.data.vertices.foreach_set('select', [0, 0, 0, 0, 1, 1, 1, 1])
     # change model_style for selected atoms
     bpy.ops.batoms.apply_model_style_selected(model_style='1')
-    assert au111.model_style[0] == 0
-    assert au111.model_style[-1] == 1
+    assert au111.get_attribute('model_style')[0] == 0
+    assert au111.get_attribute('model_style')[-1] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`model_style` is now active. `batoms.model_style` and `batoms.scale` are now single value instead of array. In order to get the array, one can use
```python
batoms.attributes['model_style']
```
or 
```python
batoms.ge_attribute('model_style')
```