### PR TITLE
Equivalent atoms

### DIFF
--- a/batoms/bond/bondsetting.py
+++ b/batoms/bond/bondsetting.py
@@ -505,7 +505,6 @@ class BondSettings(Setting):
         for b in other:
             self[(b.species1, b.species2)] = b.as_dict()
         # new
-
         species1 = set(self.batoms.species.species_props)
         species2 = set(other.batoms.species.species_props)
         nspecies1 = species1 - species2
@@ -556,8 +555,10 @@ class BondSettings(Setting):
         Args:
             key (str): _description_
         """
-        species_props = {
-                sp: self.batoms.species.species_props[sp] for sp in key}
+        species_props = {}
+        for sp in key:
+            if sp in self.batoms.species.keys():
+                species_props[sp] = self.batoms.species.species_props[sp]
         if value:
             species_props.update(value)
         bond = self.get_bondtable(key, species_props, dcutoff=0.5)

--- a/batoms/bond/bondsetting.py
+++ b/batoms/bond/bondsetting.py
@@ -182,7 +182,7 @@ class BondSettings(Setting):
         self.batoms = batoms
         self.bonds = bonds
         if len(self) == 0:
-            self.add_from_species(self.batoms.species.keys(), dcutoff)
+            self.add_species_list(self.batoms.species.keys(), dcutoff)
         if bondsetting is not None:
             for key, data in bondsetting.items():
                 self[key] = data
@@ -517,39 +517,51 @@ class BondSettings(Setting):
                          sp2: other.batoms.species.species_props[sp2]}
                 self.add(pair, props)
 
-    def add_from_species(self, speciesList,
-                         only_default_bonds=False):
+    def add_species_list(self, speciesList,
+                         only_default=True):
+        for sp in speciesList:
+            self.add_species(sp, only_default)
+
+    def add_species(self, name,
+                         only_default=True):
         """_summary_
 
         Args:
             speciesList (_type_): _description_
             self_interaction (bool, optional): _description_. Defaults to True.
-            only_default_bonds (bool, optional): _description_. Defaults to False.
+            only_default (bool, optional): _description_. Defaults to False.
         """
         from batoms.data import default_bonds
+        species_props = self.batoms.species.species_props
         pairs = []
-        for sp1 in speciesList:
-            ele1 = sp1.split('_')[0]
-            for sp2 in speciesList:
-                ele2 = sp2.split('_')[0]
-                pair = (ele1, ele2)
-                if only_default_bonds and pair not in default_bonds:
-                    continue
-                pairs.append(pair)
+        ele = species_props[name]['element']
+        for name1, props in species_props.items():
+            ele1 = props['element']
+            if only_default:
+                pair = (ele, ele1)
+                if pair in default_bonds:
+                    pairs.append((name, name1))
+                pair = (ele1, ele)
+                if pair in default_bonds:
+                    pairs.append((name1, name))
+            else:
+                pairs.append((name, name1))
+                pairs.append((name1, name))
         for pair in pairs:
             self.add(pair)
 
-    def add(self, pair, species_props = None):
+    def add(self, key, value = None):
         """_summary_
 
         Args:
-            pair (_type_): _description_
+            key (str): _description_
         """
-        if species_props is None:
-            species_props = {
-                sp: self.batoms.species.species_props[sp] for sp in pair}
-        bond = self.get_bondtable(pair, species_props, dcutoff=0.5)
-        self[pair] = bond
+        species_props = {
+                sp: self.batoms.species.species_props[sp] for sp in key}
+        if value:
+            species_props.update(value)
+        bond = self.get_bondtable(key, species_props, dcutoff=0.5)
+        self[key] = bond
 
     def remove(self, index):
         """
@@ -669,10 +681,11 @@ class BondSettings(Setting):
         sp2 = pair[1]
         bondmax = props[sp1]['radius'] + \
             props[sp2]['radius'] + dcutoff
-        if pair in default_bonds:
-            search = default_bonds[pair][0]
-            polyhedra = default_bonds[pair][1]
-            bondtype = default_bonds[pair][2]
+        pair_ele = (props[sp1]['element'], props[sp2]['element'])
+        if pair_ele in default_bonds:
+            search = default_bonds[pair_ele][0]
+            polyhedra = default_bonds[pair_ele][1]
+            bondtype = default_bonds[pair_ele][2]
         else:
             search = 1
             polyhedra = 0

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -521,12 +521,12 @@ class Bspecies(Setting):
         species_props = {}
         instancers = self.instancers
         species_props = {}
-        for sp in self.species:
-            radius = instancers[sp].batoms.atom.radius
-            matname = instancers[sp].material_slots[0].name
-            mat = bpy.data.materials.get(matname)
-            color = mat.node_tree.nodes[0].inputs[0].default_value[:]
-            species_props[sp] = {'radius': radius, 'color': color}
+        species = self.species
+        for name, sp in self.species.items():
+            radius = sp.radius
+            color = sp.color
+            species_props[name] = {'radius': radius, 'color': color,
+                'element': sp.main_element}
         return species_props
 
     def __add__(self, other):

--- a/batoms/gui/view3d_mt_object_context_menu.py
+++ b/batoms/gui/view3d_mt_object_context_menu.py
@@ -105,6 +105,7 @@ class VIEW3D_MT_object_context_batoms(Menu):
         layout.operator("batoms.copy", text="Copy", icon='LAYER_ACTIVE')
         layout.operator("batoms.delete_selected", text="Delete",
                         icon='FORCE_LENNARDJONES')
+        layout.operator("batoms.auto_build_species", text="Auto build species", icon='LAYER_ACTIVE')
 
         layout.separator()
 

--- a/batoms/ops/__init__.py
+++ b/batoms/ops/__init__.py
@@ -56,6 +56,7 @@ classes = [
     ops_batoms.BatomsCopy,
     ops_batoms.ApplyModelStyleSelected,
     ops_batoms.ApplyLabel,
+    ops_batoms.BatomsAutoBuildSpecies,
     ops_batoms.AddSurface,
     ops_batoms.AddRootSurface,
     ops_batoms.BatomsJoin,

--- a/batoms/ops/ops_batoms.py
+++ b/batoms/ops/ops_batoms.py
@@ -387,7 +387,23 @@ class ApplyLabel(OperatorBatoms):
             .format(self.label, context.object.batoms.label))
         return {'FINISHED'}
 
+class BatomsAutoBuildSpecies(OperatorBatoms):
+    bl_idname = "batoms.auto_build_species"
+    bl_label = "Auto build species"
+    bl_options = {'REGISTER', 'UNDO'}
+    bl_description = ("Auto build species")
 
+    tol: FloatProperty(
+        name="tol", default=1e-5,
+        description="tol")
+
+    def execute(self, context):
+        batoms = Batoms(label=context.object.batoms.label)
+        batoms.auto_build_species(self.tol)
+        bpy.context.view_layer.objects.active = batoms.obj
+        self.report({"INFO"}, "Auto build species for {}"
+            .format(context.object.batoms.label))
+        return {'FINISHED'}
 # ===========================================
 # Below for Edit mode
 # ===========================================

--- a/batoms/polyhedra/polyhedrasetting.py
+++ b/batoms/polyhedra/polyhedrasetting.py
@@ -32,7 +32,7 @@ class PolyhedraSettings(Setting):
         self.batoms = batoms
         self.polyhedras = polyhedras
         if len(self) == 0:
-            self.set_default(self.batoms.species.species_props)
+            self.add_species_list(self.batoms.species.keys())
         if polyhedrasetting is not None:
             for key, data in polyhedrasetting.items():
                 self[key] = data
@@ -80,14 +80,23 @@ class PolyhedraSettings(Setting):
             self[sp] = props
             
 
-    def add(self, polyhedras):
-        if isinstance(polyhedras, str):
-            polyhedras = [polyhedras]
-        for sp in polyhedras:
-            props = self.batoms.species.species_props[sp]
-            props['color'] = (props['color'][0], props['color'][1], props['color'][2], 0.8)
-            props['species'] = sp
-            self[sp] = props
+    def add(self, key, value = None):
+        props = self.batoms.species.species_props[key]
+        if value:
+            props.update(value)
+        props['color'] = (props['color'][0], props['color'][1], props['color'][2], 0.8)
+        props['species'] = key
+        self[key] = props
+    
+    def add_species_list(self, species_list, only_default=True):
+        for sp in species_list:
+            self.add_species(sp, only_default)
+
+    def add_species(self, name, only_default=True):
+        species_props = self.batoms.species.species_props[name]
+        if only_default and species_props['element'] not in default_polyhedras:
+            return
+        self.add(name, species_props)
 
     def __repr__(self) -> str:
         s = "-"*60 + "\n"

--- a/batoms/utils/__init__.py
+++ b/batoms/utils/__init__.py
@@ -287,6 +287,14 @@ def get_equivalent_indices(no, indices):
     indices = indices.tolist()
     return indices
 
+def get_equivalent_atoms(atoms, tol = 1e-5):
+    """Get equivalent atoms using spglib.
+    """
+    import spglib
+    atoms = (atoms.get_cell(), atoms.get_scaled_positions(),
+                   atoms.numbers)
+    symmetry_data = spglib.get_symmetry_dataset(atoms, symprec=tol)
+    return symmetry_data['equivalent_atoms']
 
 def local2global(positions, matrix, reversed=False):
     if reversed:

--- a/tests/datas/magnetite.cif
+++ b/tests/datas/magnetite.cif
@@ -1,0 +1,152 @@
+#------------------------------------------------------------------------------
+#$Date: 2018-09-27 07:13:35 +0300 (Thu, 27 Sep 2018) $
+#$Revision: 211196 $
+#$URL: file:///home/coder/svn-repositories/cod/cif/1/53/97/1539747.cif $
+#------------------------------------------------------------------------------
+#
+# This file is available in the Crystallography Open Database (COD),
+# http://www.crystallography.net/
+#
+# All data on this site have been placed in the public domain by the
+# contributors.
+#
+data_1539747
+loop_
+_publ_author_name
+'Fleet, M.E.'
+_publ_section_title
+;
+ The structure of magnetite: Symmetry of cubic spinels
+;
+_journal_name_full               'Journal of Solid State Chemistry'
+_journal_page_first              75
+_journal_page_last               82
+_journal_volume                  62
+_journal_year                    1986
+_chemical_formula_sum            'Fe3 O4'
+_space_group_IT_number           216
+_symmetry_space_group_name_Hall  'F -4 2 3'
+_symmetry_space_group_name_H-M   'F -4 3 m'
+_cell_angle_alpha                90
+_cell_angle_beta                 90
+_cell_angle_gamma                90
+_cell_formula_units_Z            8
+_cell_length_a                   8.3941
+_cell_length_b                   8.3941
+_cell_length_c                   8.3941
+_cell_volume                     591.456
+_citation_journal_id_ASTM        JSSCBI
+_cod_data_source_file            Fleet_JSSCBI_1986_203.cif
+_cod_data_source_block           Fe3O4
+_cod_database_code               1539747
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+y,-x,-z
+-x,-y,z
+-y,x,-z
+x,-y,-z
+-y,-x,z
+-x,y,-z
+y,x,z
+z,x,y
+x,-z,-y
+-z,-x,y
+-x,z,-y
+z,-x,-y
+-x,-z,y
+-z,x,-y
+x,z,y
+y,z,x
+y,-z,-x
+-z,-y,x
+-y,z,-x
+z,y,x
+-y,-z,x
+-z,y,-x
+z,-y,-x
+x,y+1/2,z+1/2
+y,-x+1/2,-z+1/2
+-x,-y+1/2,z+1/2
+-y,x+1/2,-z+1/2
+x,-y+1/2,-z+1/2
+-y,-x+1/2,z+1/2
+-x,y+1/2,-z+1/2
+y,x+1/2,z+1/2
+z,x+1/2,y+1/2
+x,-z+1/2,-y+1/2
+-z,-x+1/2,y+1/2
+-x,z+1/2,-y+1/2
+z,-x+1/2,-y+1/2
+-x,-z+1/2,y+1/2
+-z,x+1/2,-y+1/2
+x,z+1/2,y+1/2
+y,z+1/2,x+1/2
+y,-z+1/2,-x+1/2
+-z,-y+1/2,x+1/2
+-y,z+1/2,-x+1/2
+z,y+1/2,x+1/2
+-y,-z+1/2,x+1/2
+-z,y+1/2,-x+1/2
+z,-y+1/2,-x+1/2
+x+1/2,y,z+1/2
+y+1/2,-x,-z+1/2
+-x+1/2,-y,z+1/2
+-y+1/2,x,-z+1/2
+x+1/2,-y,-z+1/2
+-y+1/2,-x,z+1/2
+-x+1/2,y,-z+1/2
+y+1/2,x,z+1/2
+z+1/2,x,y+1/2
+x+1/2,-z,-y+1/2
+-z+1/2,-x,y+1/2
+-x+1/2,z,-y+1/2
+z+1/2,-x,-y+1/2
+-x+1/2,-z,y+1/2
+-z+1/2,x,-y+1/2
+x+1/2,z,y+1/2
+y+1/2,z,x+1/2
+y+1/2,-z,-x+1/2
+-z+1/2,-y,x+1/2
+-y+1/2,z,-x+1/2
+z+1/2,y,x+1/2
+-y+1/2,-z,x+1/2
+-z+1/2,y,-x+1/2
+z+1/2,-y,-x+1/2
+x+1/2,y+1/2,z
+y+1/2,-x+1/2,-z
+-x+1/2,-y+1/2,z
+-y+1/2,x+1/2,-z
+x+1/2,-y+1/2,-z
+-y+1/2,-x+1/2,z
+-x+1/2,y+1/2,-z
+y+1/2,x+1/2,z
+z+1/2,x+1/2,y
+x+1/2,-z+1/2,-y
+-z+1/2,-x+1/2,y
+-x+1/2,z+1/2,-y
+z+1/2,-x+1/2,-y
+-x+1/2,-z+1/2,y
+-z+1/2,x+1/2,-y
+x+1/2,z+1/2,y
+y+1/2,z+1/2,x
+y+1/2,-z+1/2,-x
+-z+1/2,-y+1/2,x
+-y+1/2,z+1/2,-x
+z+1/2,y+1/2,x
+-y+1/2,-z+1/2,x
+-z+1/2,y+1/2,-x
+z+1/2,-y+1/2,-x
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_occupancy
+_atom_site_U_iso_or_equiv
+Fe2 Fe+2 0.5 0.5 0.5 1 0.0
+Fe3 Fe+3 0.6253 0.6253 0.6253 1 0.0
+O2 O-2 0.3817 0.3817 0.3817 1 0.0
+O1 O-2 0.8722 0.8722 0.8722 1 0.0
+Fe1 Fe+2 0 0 0 1 0.0

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -210,6 +210,8 @@ def test_replace():
 
 def test_batoms_add():
     """Merge two Batoms objects"""
+    from batoms import Batoms
+    from ase.build import molecule
     bpy.ops.batoms.delete()
     h2o = Batoms("h2o", from_ase=molecule("H2O"))
     co = Batoms("co", from_ase=molecule("CO"))

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -100,6 +100,15 @@ def test_batoms_species():
     h2o.replace([0], "X")
     h2o["X"].color = [0.8, 0.8, 0.0, 0.3]
 
+def test_auto_build_species():
+    """auto build species use spglib"""
+    from batoms.bio.bio import read
+    bpy.ops.batoms.delete()
+    magnetite = read("../tests/datas/magnetite.cif")
+    magnetite.auto_build_species()
+    assert len(magnetite.species) == 5
+    assert len(magnetite.bonds.setting) == 10
+    assert len(magnetite.polyhedras.setting) == 3
 
 def test_batoms_write():
     """Export Batoms to structure file

--- a/tests/test_polyhedrasetting.py
+++ b/tests/test_polyhedrasetting.py
@@ -27,21 +27,12 @@ def test_polyhedra_species():
     tio2.replace([0], 'Ti_1')
     tio2.bonds.setting
     tio2.model_style = 2
-    assert len(tio2.polyhedras) == 6
-    # add a bond between Ti_1 and O
-    tio2.bonds.setting.add(('Ti_1', 'O'))
-    tio2.bonds.setting
-    # In the Bondpair Ti_1-O, the Polyhedra is False, we can set it to True by:
-    tio2.bonds.setting[('Ti_1', 'O')].polyhedra = True
-    tio2.bonds.setting
-    # Also add Ti_1 to polyhedras.
-    tio2.polyhedras.setting.add('Ti_1')
-    assert len(tio2.polyhedras.setting) == 2
-    # To make the polyhedra different from another Ti species, we change its color.
-    tio2.polyhedras.setting['Ti_1'].color = (0, 1, 1, 0.8)
-    tio2.polyhedras.setting
-    tio2.model_style = 2
     assert len(tio2.polyhedras) == 12
+    # remove Ti_1 to polyhedras.
+    tio2.polyhedras.setting.remove('Ti_1')
+    assert len(tio2.polyhedras.setting) == 1
+    tio2.model_style = 2
+    assert len(tio2.polyhedras) == 6
 
 
 def test_polyhedra_molecule():


### PR DESCRIPTION
#144 
Now,  we can auto-build species based on equivalent_atoms.

In the `magnetite.cif` file, there are three Fe species and two O species:
```
Fe2 Fe+2 0.5 0.5 0.5 1 0.0
Fe3 Fe+3 0.6253 0.6253 0.6253 1 0.0
O2 O-2 0.3817 0.3817 0.3817 1 0.0
O1 O-2 0.8722 0.8722 0.8722 1 0.0
Fe1 Fe+2 0 0 0 1 0.0
```

When reading a CIF file using `ase.io.read`, the symmetry information is lost. Especially the species (symmetrically equivalent atoms) are lost.

```python
>>> from batoms.bio.bio import read
>>> bpy.ops.batoms.delete()
>>> magnetite = read("../tests/datas/magnetite.cif")
>>> magnetite.species
Bspecies(species = 'Fe', elements = [('Fe', 1.0)], color = [0.88 0.4  0.2  1.  ])
Bspecies(species = 'O', elements = [('O', 1.0)], color = [1.   0.05 0.05 1.  ])
```

By using `auto_build_species`, we can re-biuld the species based on equivalent_atoms using `spglib` libray:
```python
>>> magnetite.auto_build_species()
>>> magnetite.species
Bspecies(species = 'Fe', elements = [('Fe', 1.0)], color = [0.88 0.4  0.2  1.  ])
Bspecies(species = 'O', elements = [('O', 1.0)], color = [1.   0.05 0.05 1.  ])
Bspecies(species = 'Fe_1', elements = [('Fe', 1.0)], color = [0.88 0.4  0.2  1.  ])
Bspecies(species = 'Fe_2', elements = [('Fe', 1.0)], color = [0.88 0.4  0.2  1.  ])
Bspecies(species = 'O_1', elements = [('O', 1.0)], color = [1.   0.05 0.05 1.  ])
```

Application.
In this case, one can easily draw different polyhedra for different species.
Change color for the polyhedra of different species.
```python
>>> magnetite.polyhedras.setting['Fe_1'].color[:] = [0, 0.8, 0, 0.8]
>>> magnetite.polyhedras.setting['Fe_2'].color[:] = [0, 0, 0.8, 0.8]
>>> magnetite.model_style = 2
```
<img  width=500 src="https://user-images.githubusercontent.com/11457659/174911671-b44f51c9-74c1-4a83-a597-aa915d9508c5.png" />


