### PR TITLE
fix show_unit_cell

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -177,6 +177,8 @@ class Batoms(BaseCollection, ObjectGN):
             self.color_style = color_style
             if movie:
                 self.set_frames()
+            self.show_unit_cell = show_unit_cell
+            
         self.ribbon = Ribbon(self.label, batoms=self, datas=info, update=True)
         self._render = None
         self._bonds = None
@@ -190,7 +192,6 @@ class Batoms(BaseCollection, ObjectGN):
         self._cavity = None
         show_index()
         self.hideOneLevel()
-        self.show_unit_cell = show_unit_cell
 
     def set_collection(self, label):
         """Build main collection and its child collections.

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -190,6 +190,7 @@ class Batoms(BaseCollection, ObjectGN):
         self._cavity = None
         show_index()
         self.hideOneLevel()
+        self.show_unit_cell = show_unit_cell
 
     def set_collection(self, label):
         """Build main collection and its child collections.
@@ -599,8 +600,12 @@ class Batoms(BaseCollection, ObjectGN):
 
     @show_unit_cell.setter
     def show_unit_cell(self, show_unit_cell):
-        self.coll.batoms.show_unit_cell = show_unit_cell
-        self.cell.draw_cell()
+        if show_unit_cell:
+            self.coll.batoms.show_unit_cell = show_unit_cell
+            self.cell.draw()
+        else:
+            name = '%s_%s_%s' % (self.label, 'cell', 'cylinder')
+            self.cell.delete_obj(name)
 
     @property
     def radius(self):
@@ -1712,6 +1717,8 @@ class Batoms(BaseCollection, ObjectGN):
         self.draw_ball_and_stick()
         self.draw_polyhedra()
         self.draw_wireframe()
+        if self.show_unit_cell:
+            self.cell.draw()
 
     def draw_space_filling(self, scale=1.0):
         mask = np.where(self.model_style_array == 0, True, False)

--- a/batoms/draw/__init__.py
+++ b/batoms/draw/__init__.py
@@ -35,13 +35,19 @@ def draw_cylinder(
     Draw cylinder.
     """
     from batoms.data.source_data import bond_source
-    if len(datas['centers']) == 0:
-        return 0
+    # materials
     material = create_material(name,
                                datas['color'],
                                node_type=node_type,
                                node_inputs=node_inputs,
                                material_style=material_style)
+    #
+    mesh = bpy.data.meshes.new(name)
+    obj = bpy.data.objects.new(name, mesh)
+    obj.data.materials.append(material)
+    if len(datas['centers']) == 0:
+        return obj
+    
     source = bond_source[datas['vertices']]
     # tstart = time()
     verts, faces = cylinder_mesh_from_vec(
@@ -51,9 +57,7 @@ def draw_cylinder(
     mesh.from_pydata(verts, [], faces)
     mesh.update()
     mesh.polygons.foreach_set('use_smooth', [True]*len(mesh.polygons))
-    obj = bpy.data.objects.new(name, mesh)
     obj.data = mesh
-    obj.data.materials.append(material)
     #
     for name, inputs in datas['battr_inputs'].items():
         battr = getattr(obj, name)


### PR DESCRIPTION
Quick patch for `show_unit_cell`. Now, this parameter should work.


@alchem0x2A  However, since there are two cell objects, one is created by the `cell.draw()` function, another is created by the geometry node, and it is a little bit complex to keep both updated at the same time. I will look at this in the future.