### PR TITLE
Fix model style update & Named Attribute Node

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -1644,32 +1644,6 @@ class Batoms(BaseCollection, ObjectGN):
     def cavity(self, cavity):
         self._cavity = cavity
 
-    def get_arrays_with_boundary(self):
-        """
-        get arrays with boundary atoms
-        """
-        # arrays = self.arrays
-        arrays_b = None
-        if self._boundary is not None:
-            # arrays_b = {
-            #         'indices': np.arange(natom),
-            #         'species': arrays['species'],
-            #         'positions': arrays['positions'],
-            #         'offsets': np.zeros((natom, 3)),
-            #         }
-            arrays_b = self.boundary.boundary_data
-            # arrays_b['positions'] = np.append(arrays_b['positions'],
-            #             boundary_data['positions'], axis = 0)
-            # arrays_b['indices'] = np.append(arrays_b['indices'],
-            #             boundary_data['indices'])
-            # arrays_b['species'] = np.append(arrays_b['species'],
-            #             boundary_data['species'])
-            # arrays_b['offsets'] = np.append(arrays_b['offsets'],
-            #             boundary_data['offsets'], axis = 0)
-        else:
-            arrays_b = None
-        return arrays_b
-
     @property
     def render(self):
         """Render object."""
@@ -1746,6 +1720,8 @@ class Batoms(BaseCollection, ObjectGN):
     def draw_space_filling(self, scale=1.0):
         mask = np.where(self.model_style_array == 0, True, False)
         self.set_attribute_with_indices('scale', mask, scale)
+        self.boundary.update()
+
 
     def draw_ball_and_stick(self, scale=0.4):
         mask = np.where(self.model_style_array >= 1, True, False)
@@ -1755,6 +1731,7 @@ class Batoms(BaseCollection, ObjectGN):
             return
         self.set_attribute_with_indices('scale', mask, scale)
         self.bond.hide = False
+        self.boundary.hide = False
         self.bond.update()
 
     def draw_polyhedra(self, scale=0.4):
@@ -1772,9 +1749,13 @@ class Batoms(BaseCollection, ObjectGN):
             self.bond.search_bond.hide = False
             # self.bond.update()
         if self.polyhedra_style == 1:
-            # hide bond
+            # only hide bond
             self.set_attribute_with_indices('scale', mask, scale)
             self.bond.hide = True
+            # show atoms
+            if self.bond._search_bond is not None:
+                self.bond.search_bond.hide = False
+            self.boundary.hide = False
         elif self.polyhedra_style == 2:
             # hide bond and atoms, except center atoms
             for b in self.bond.settings:
@@ -1785,7 +1766,7 @@ class Batoms(BaseCollection, ObjectGN):
                     mask[mask1] = False
             scale = 0
             self.set_attribute_with_indices('scale', mask, scale)
-            self.boundary.hide = True
+            # self.boundary.hide = True
             self.bond.hide = True
             self.bond.search_bond.hide = True
             # self.set_attribute_with_indices('show', mask, False)

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -567,6 +567,14 @@ class Batoms(BaseCollection, ObjectGN):
         return int(self.coll.batoms.model_style)
 
     def set_model_style(self, model_style):
+        if int(model_style) == 0:
+            self.scale = 1
+        elif int(model_style) == 1:
+            self.scale = 0.4
+        elif int(model_style) == 2:
+            self.scale = 0.4
+        elif int(model_style) == 3:
+            self.scale = 0.0001
         self.coll.batoms.model_style = str(model_style)
         model_style_array = np.ones(len(self), dtype=int)*int(model_style)
         self.set_model_style_array(model_style_array)
@@ -1717,24 +1725,24 @@ class Batoms(BaseCollection, ObjectGN):
         if self.show_unit_cell:
             self.cell.draw()
 
-    def draw_space_filling(self, scale=1.0):
+    def draw_space_filling(self):
         mask = np.where(self.model_style_array == 0, True, False)
-        self.set_attribute_with_indices('scale', mask, scale)
+        self.set_attribute_with_indices('scale', mask, self.scale)
         self.boundary.update()
 
 
-    def draw_ball_and_stick(self, scale=0.4):
+    def draw_ball_and_stick(self):
         mask = np.where(self.model_style_array >= 1, True, False)
         if not mask.any():
             from batoms.bond.bond import default_bond_datas
             self.bond.set_arrays(default_bond_datas.copy())
             return
-        self.set_attribute_with_indices('scale', mask, scale)
+        self.set_attribute_with_indices('scale', mask, self.scale)
         self.bond.hide = False
         self.boundary.hide = False
         self.bond.update()
 
-    def draw_polyhedra(self, scale=0.4):
+    def draw_polyhedra(self):
         mask = np.where(self.model_style_array == 2, True, False)
         if not mask.any():
             from batoms.polyhedra.polyhedra import default_polyhedra_datas
@@ -1743,14 +1751,14 @@ class Batoms(BaseCollection, ObjectGN):
         self.polyhedra.update()
         self.set_attribute_with_indices('show', mask, True)
         if self.polyhedra_style == 0:
-            self.set_attribute_with_indices('scale', mask, scale)
+            self.set_attribute_with_indices('scale', mask, self.scale)
             self.boundary.hide = False
             self.bond.hide = False
             self.bond.search_bond.hide = False
             # self.bond.update()
         if self.polyhedra_style == 1:
             # only hide bond
-            self.set_attribute_with_indices('scale', mask, scale)
+            self.set_attribute_with_indices('scale', mask, self.scale)
             self.bond.hide = True
             # show atoms
             if self.bond._search_bond is not None:
@@ -1762,17 +1770,17 @@ class Batoms(BaseCollection, ObjectGN):
                 if b.polyhedra:
                     mask1 = np.where(
                         self.attributes['species'] == b.species1, True, False)
-                    self.set_attribute_with_indices('scale', mask1, scale)
+                    self.set_attribute_with_indices('scale', mask1, self.scale)
                     mask[mask1] = False
             scale = 0
-            self.set_attribute_with_indices('scale', mask, scale)
+            self.set_attribute_with_indices('scale', mask, self.scale)
             # self.boundary.hide = True
             self.bond.hide = True
             self.bond.search_bond.hide = True
             # self.set_attribute_with_indices('show', mask, False)
         elif self.polyhedra_style == 3:
             # hide all bond and atoms
-            scale = 0
+            scale = 0.0001
             self.set_attribute_with_indices('scale', mask, scale)
             self.boundary.hide = True
             self.bond.hide = True
@@ -1782,7 +1790,7 @@ class Batoms(BaseCollection, ObjectGN):
     def draw_wireframe(self):
         mask = np.where(self.model_style_array == 3, True, False)
         # self.set_attribute_with_indices('show', mask, 0)
-        self.set_attribute_with_indices('scale', mask, 0.0001)
+        self.set_attribute_with_indices('scale', mask, self.scale)
         # self.update(mask)
 
     def as_ase(self, local=True, with_attribute=True):

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -575,6 +575,8 @@ class Batoms(BaseCollection, ObjectGN):
             self.scale = 0.4
         elif int(model_style) == 3:
             self.scale = 0.0001
+        scale = np.ones(len(self))*self.scale
+        self.set_attribute('scale', scale)
         self.coll.batoms.model_style = str(model_style)
         model_style_array = np.ones(len(self), dtype=int)*int(model_style)
         self.set_model_style_array(model_style_array)
@@ -1726,8 +1728,8 @@ class Batoms(BaseCollection, ObjectGN):
             self.cell.draw()
 
     def draw_space_filling(self):
-        mask = np.where(self.model_style_array == 0, True, False)
-        self.set_attribute_with_indices('scale', mask, self.scale)
+        # mask = np.where(self.model_style_array == 0, True, False)
+        # self.set_attribute_with_indices('scale', mask, self.scale)
         self.boundary.update()
 
 
@@ -1737,7 +1739,7 @@ class Batoms(BaseCollection, ObjectGN):
             from batoms.bond.bond import default_bond_datas
             self.bond.set_arrays(default_bond_datas.copy())
             return
-        self.set_attribute_with_indices('scale', mask, self.scale)
+        # self.set_attribute_with_indices('scale', mask, self.scale)
         self.bond.hide = False
         self.boundary.hide = False
         self.bond.update()
@@ -1751,14 +1753,14 @@ class Batoms(BaseCollection, ObjectGN):
         self.polyhedra.update()
         self.set_attribute_with_indices('show', mask, True)
         if self.polyhedra_style == 0:
-            self.set_attribute_with_indices('scale', mask, self.scale)
+            # self.set_attribute_with_indices('scale', mask, self.scale)
             self.boundary.hide = False
             self.bond.hide = False
             self.bond.search_bond.hide = False
             # self.bond.update()
         if self.polyhedra_style == 1:
             # only hide bond
-            self.set_attribute_with_indices('scale', mask, self.scale)
+            # self.set_attribute_with_indices('scale', mask, self.scale)
             self.bond.hide = True
             # show atoms
             if self.bond._search_bond is not None:
@@ -1773,7 +1775,7 @@ class Batoms(BaseCollection, ObjectGN):
                     self.set_attribute_with_indices('scale', mask1, self.scale)
                     mask[mask1] = False
             scale = 0
-            self.set_attribute_with_indices('scale', mask, self.scale)
+            # self.set_attribute_with_indices('scale', mask, self.scale)
             # self.boundary.hide = True
             self.bond.hide = True
             self.bond.search_bond.hide = True

--- a/batoms/bond/bond.py
+++ b/batoms/bond/bond.py
@@ -650,7 +650,7 @@ class Bond(BaseCollection, ObjectGN):
         # clean_coll_objects(self.coll, 'bond')
         frames = self.batoms.get_frames()
         arrays = self.batoms.arrays
-        array_b = self.batoms.boundary.boundary_data
+        boundary_data = self.batoms.boundary.boundary_data
         show = arrays['show'].astype(bool)
         species = arrays['species'][show]
         # frames_boundary = self.batoms.get_frames(self.batoms.batoms_boundary)
@@ -668,11 +668,13 @@ class Bond(BaseCollection, ObjectGN):
                     self.build_bondlists(species, positions, self.batoms.cell,
                                         self.batoms.pbc, setting)
                 # build bondlist for boundary atoms
-                bondlist = self.build_bondlists_with_boundary(
-                    array_b, bondlist, bonddatas,
-                    peciesBondDatas,
-                    molPeciesDatas)
-                bondlist = self.check_boundary(bondlist)
+                # for molecule with cell == [0, 0, 0], skip
+                if boundary_data is not None:
+                    bondlist = self.build_bondlists_with_boundary(
+                        boundary_data, bondlist, bonddatas,
+                        peciesBondDatas,
+                        molPeciesDatas)
+                    bondlist = self.check_boundary(bondlist)
                 # search molecule
                 # search bond
                 if self.show_search:

--- a/batoms/bond/bond.py
+++ b/batoms/bond/bond.py
@@ -650,7 +650,7 @@ class Bond(BaseCollection, ObjectGN):
         # clean_coll_objects(self.coll, 'bond')
         frames = self.batoms.get_frames()
         arrays = self.batoms.arrays
-        array_b = self.batoms.get_arrays_with_boundary()
+        array_b = self.batoms.boundary.boundary_data
         show = arrays['show'].astype(bool)
         species = arrays['species'][show]
         # frames_boundary = self.batoms.get_frames(self.batoms.batoms_boundary)
@@ -668,15 +668,15 @@ class Bond(BaseCollection, ObjectGN):
                     self.build_bondlists(species, positions, self.batoms.cell,
                                         self.batoms.pbc, setting)
                 # build bondlist for boundary atoms
-                if array_b is not None:
-                    bondlist = self.build_bondlists_with_boundary(
-                        array_b, bondlist, bonddatas,
-                        peciesBondDatas,
-                        molPeciesDatas)
-                    bondlist = self.check_boundary(bondlist)
+                bondlist = self.build_bondlists_with_boundary(
+                    array_b, bondlist, bonddatas,
+                    peciesBondDatas,
+                    molPeciesDatas)
+                bondlist = self.check_boundary(bondlist)
                 # search molecule
                 # search bond
                 if self.show_search:
+                    self.search_bond.hide = False
                     self.search_bond.update(
                         bondlist, peciesBondDatas, molPeciesDatas,
                         arrays, self.batoms.cell)

--- a/batoms/bond/search_bond.py
+++ b/batoms/bond/search_bond.py
@@ -140,6 +140,7 @@ class SearchBond(ObjectGN):
         # print('boundary: build_object: {0:10.2f} s'.format(time() - tstart))
 
     def update(self, bondlist, mollists, moldatas, arrays, cell):
+        self.hide = False
         search_bond_data = self.calc_search_bond_data(
             bondlist, mollists, moldatas, arrays, cell)
         self.set_arrays(search_bond_data)

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -329,6 +329,9 @@ class Boundary(ObjectGN):
         # object_mode()
         # clean_coll_objects(self.coll, 'bond')
         self.hide = False
+        if not self.active:
+            self.set_arrays(default_boundary_datas)
+            return
         frames = self.batoms.get_frames()
         images = self.batoms.as_ase()
         nframe = self.batoms.nframe
@@ -379,6 +382,14 @@ class Boundary(ObjectGN):
         return obj_o
 
     @property
+    def active(self):
+        return self.batoms.coll.batoms.boundary.active
+    
+    @active.setter
+    def active(self, value):
+        self.batoms.coll.batoms.boundary.active = value
+
+    @property
     def boundary(self):
         return self.get_boundary()
 
@@ -396,7 +407,13 @@ class Boundary(ObjectGN):
                     boundary = np.array(boundary)
             else:
                 raise Exception('Wrong boundary setting!')
+            if np.isclose(boundary[:].flatten(), np.array([0, 1, 0, 1, 0, 1])).all():
+                self.active = False
+            else:
+                self.active = True
             self.batoms.coll.batoms.boundary.boundary = boundary[:].flatten()
+        else:
+            self.active = False
         self.update()
         # self.batoms.draw()
 
@@ -417,6 +434,8 @@ class Boundary(ObjectGN):
         elif dnvert < 0:
             self.delete_vertices_bmesh(range(-dnvert))
             self.delete_vertices_bmesh(range(-dnvert), self.obj_o)
+        if len(arrays["positions"]) == 0: 
+            return
         self.positions = arrays["positions"][0]
         self.offsets = arrays["offsets"][0]
         self.set_frames(arrays)
@@ -464,9 +483,9 @@ class Boundary(ObjectGN):
 
     def get_boundary_data(self, include_batoms=False):
         """
-        check cell voluem
-        if < 1e-6, invalid cell and boundary.
         """
+        # check cell voluem
+        # if < 1e-6, invalid cell and boundary.
         if self.batoms.cell.volume < 1e-6:
             return None
         arrays = self.arrays

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -398,7 +398,7 @@ class Boundary(ObjectGN):
                 raise Exception('Wrong boundary setting!')
             self.batoms.coll.batoms.boundary.boundary = boundary[:].flatten()
         self.update()
-        self.batoms.draw()
+        # self.batoms.draw()
 
     def get_boundary(self):
         boundary = np.array(self.batoms.coll.batoms.boundary.boundary)
@@ -464,8 +464,11 @@ class Boundary(ObjectGN):
 
     def get_boundary_data(self, include_batoms=False):
         """
-        using foreach_get and foreach_set to improve performance.
+        check cell voluem
+        if < 1e-6, invalid cell and boundary.
         """
+        if self.batoms.cell.volume < 1e-6:
+            return None
         arrays = self.arrays
         boundary_data = {'positions': arrays['positions'],
                          'species': arrays['species'],

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -299,6 +299,7 @@ class Boundary(ObjectGN):
         """
         # object_mode()
         # clean_coll_objects(self.coll, 'bond')
+        self.hide = False
         frames = self.batoms.get_frames()
         images = self.batoms.as_ase()
         nframe = self.batoms.nframe
@@ -368,6 +369,7 @@ class Boundary(ObjectGN):
                 raise Exception('Wrong boundary setting!')
             self.batoms.coll.batoms.boundary.boundary = boundary[:].flatten()
         self.update()
+        self.batoms.draw()
 
     def get_boundary(self):
         boundary = np.array(self.batoms.coll.batoms.boundary.boundary)

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -184,9 +184,7 @@ class Boundary(ObjectGN):
         gn.node_group.links.new(
             JoinGeometry.outputs['Geometry'], GroupOutput.inputs['Geometry'])
         # ------------------------------------------------------------------
-        # calculate bond vector, length, rotation based on the index
-        # Get four positions from batoms, bond and the second bond for
-        # high order bond plane
+        # transform postions of batoms to boundary
         ObjectBatoms = get_nodes_by_name(gn.node_group.nodes,
                                          '%s_ObjectBatoms' % self.label,
                                          'GeometryNodeObjectInfo')
@@ -206,7 +204,7 @@ class Boundary(ObjectGN):
         gn.node_group.links.new(GroupInput.outputs[1],
                                 TransferBatoms.inputs['Index'])
         # ------------------------------------------------------------------
-        # add positions with offsets
+        # calculate offset for boundary atoms
         # transfer offsets from object self.obj_o
         ObjectOffsets = get_nodes_by_name(gn.node_group.nodes,
                                           '%s_ObjectOffsets' % (self.label),
@@ -231,6 +229,8 @@ class Boundary(ObjectGN):
         VectorAdd = get_nodes_by_name(gn.node_group.nodes,
                                       '%s_VectorAdd' % (self.label),
                                       'ShaderNodeVectorMath')
+        # ------------------------------------------------------------------
+        # add positions with offsets
         VectorAdd.operation = 'ADD'
         gn.node_group.links.new(TransferBatoms.outputs[0], VectorAdd.inputs[0])
         gn.node_group.links.new(OffsetNode.outputs[0], VectorAdd.inputs[1])
@@ -242,6 +242,27 @@ class Boundary(ObjectGN):
             GroupInput.outputs['Geometry'], SetPosition.inputs['Geometry'])
         gn.node_group.links.new(
             VectorAdd.outputs[0], SetPosition.inputs['Position'])
+        #
+        # ------------------------------------------------------------------
+        # transform scale of batoms to boundary
+        if bpy.app.version_string >= '3.2.0':
+            ScaleBatoms = get_nodes_by_name(gn.node_group.nodes,
+                                            '%s_ScaleBatoms' % (self.label),
+                                            'GeometryNodeInputNamedAttribute')
+            # need to be "FLOAT_VECTOR", because scale is "FLOAT_VECTOR"
+            ScaleBatoms.data_type = "FLOAT_VECTOR"
+            ScaleBatoms.inputs[0].default_value = "scale"
+            TransferScale = get_nodes_by_name(gn.node_group.nodes,
+                                            '%s_TransferScale' % (self.label),
+                                            'GeometryNodeAttributeTransfer')
+            TransferScale.mapping = 'INDEX'
+            TransferScale.data_type = 'FLOAT_VECTOR'
+            gn.node_group.links.new(ObjectBatoms.outputs['Geometry'],
+                                    TransferScale.inputs[0])
+            gn.node_group.links.new(ScaleBatoms.outputs['Attribute'],
+                                    TransferScale.inputs['Attribute'])
+            gn.node_group.links.new(GroupInput.outputs[1],
+                                    TransferScale.inputs['Index'])
 
     def add_geometry_node(self, spname):
         """
@@ -281,8 +302,16 @@ class Boundary(ObjectGN):
         gn.node_group.links.new(
             GroupInput.outputs[2], CompareSpecies.inputs[0])
         gn.node_group.links.new(GroupInput.outputs[3], BoolShow.inputs[0])
-        gn.node_group.links.new(
-            GroupInput.outputs[6], InstanceOnPoint.inputs['Scale'])
+        # transfer scale
+        if bpy.app.version_string >= '3.2.0':
+            TransferScale = get_nodes_by_name(gn.node_group.nodes,
+                                            '%s_TransferScale' % (self.label),
+                                            'GeometryNodeAttributeTransfer')
+            gn.node_group.links.new(
+                TransferScale.outputs[0], InstanceOnPoint.inputs['Scale'])
+        else:
+            gn.node_group.links.new(
+                GroupInput.outputs[6], InstanceOnPoint.inputs['Scale'])
         gn.node_group.links.new(CompareSpecies.outputs[0], BoolShow.inputs[1])
         gn.node_group.links.new(
             BoolShow.outputs['Boolean'], InstanceOnPoint.inputs['Selection'])

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -81,6 +81,7 @@ def get_active_batoms():
     if context.object and context.object.batoms.type != 'OTHER':
         mode = context.object.mode
         batoms = Batoms(label=context.object.batoms.label)
+        bpy.context.view_layer.objects.active = batoms.obj
         bpy.ops.object.mode_set(mode=mode)
         return batoms
     return None

--- a/batoms/internal_data/bpy_data.py
+++ b/batoms/internal_data/bpy_data.py
@@ -197,6 +197,7 @@ class Bboundary(Base):
     """
     name: StringProperty(name="name")
     flag: BoolProperty(name="flag", default=False)
+    active: BoolProperty(name="active", default=False)
     label: StringProperty(name="label", default='batoms')
     boundary: FloatVectorProperty(name="boundary", default=[
                                   0.0, 1.0, 0.0, 1.0, 0.0, 1.0], size=6)
@@ -211,6 +212,7 @@ class Bboundary(Base):
             'name': self.name,
             'flag': self.flag,
             'label': self.label,
+            'active': self.active,
             'color': self.color[:],
             'boundary': self.boundary[:],
             'scale': self.scale,

--- a/batoms/ops/ops_batoms.py
+++ b/batoms/ops/ops_batoms.py
@@ -481,7 +481,18 @@ class ApplyModelStyleSelected(OperatorBatoms):
         indices = get_selected_vertices(context.object)
         model_style_array = batoms.get_attribute("model_style")
         model_style_array[indices] = int(self.model_style)
+        scale_array = batoms.get_attribute("scale")
+        if int(self.model_style) == 0:
+            scale = 1
+        elif int(self.model_style) == 1:
+            scale = 0.4
+        elif int(self.model_style) == 2:
+            scale = 0.4
+        elif int(self.model_style) == 3:
+            scale = 0.0001
+        scale_array[indices] = scale
         batoms.set_model_style_array(model_style_array)
+        batoms.set_attributes({'scale': scale_array})
         batoms.obj.select_set(True)
         self.report({"INFO"}, "Model style of {} atoms are changed to {}".format(len(indices), self.model_style))
         bpy.context.view_layer.objects.active = batoms.obj

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -84,7 +84,7 @@ def test_model_style():
     tio2.polyhedra_style = 2
     assert tio2.bond.hide == True
     assert tio2.bond.search_bond.hide == True
-    assert tio2.boundary.hide == True
+    assert tio2.boundary.hide == False
     #
     tio2.polyhedra_style = 1
     assert tio2.bond.hide == True

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -71,6 +71,26 @@ def test_batoms_parameters():
     assert np.isclose(h2o.scale, 0.5)
 
 
+def test_model_style():
+    from batoms import Batoms
+    from batoms.bio.bio import read
+    tio2 = read("../tests/datas/tio2.cif")
+    tio2.boundary = 0.1
+    tio2.bond.show_search = True
+    tio2.model_style = 2
+    assert tio2.bond.search_bond.hide == False
+    assert tio2.boundary.hide == False
+    #
+    tio2.polyhedra_style = 2
+    assert tio2.bond.hide == True
+    assert tio2.bond.search_bond.hide == True
+    assert tio2.boundary.hide == True
+    #
+    tio2.polyhedra_style = 1
+    assert tio2.bond.hide == True
+    assert tio2.bond.search_bond.hide == False
+    assert tio2.boundary.hide == False
+
 
 def test_batoms_write():
     """Export Batoms to structure file


### PR DESCRIPTION
Keep model update when setting `model_style` and `polyhedra_style`



A new feature from Blender 3.2
---------------------------------------------------
In Blender 3.2, there is a new node called `Named Atrribute`. This is very useful to transfer custom properties in Geometry Node. Using this node, we can easily transfer the `scale` attribute from Batoms object to its `boundary` and `search_bond` objects.