### PR TITLE
update GN & fix color for species

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -130,6 +130,17 @@ class Batoms(BaseCollection, ObjectGN):
         self.obj_name = label
         ObjectGN.__init__(self, label)
         BaseCollection.__init__(self, coll_name=label)
+        self._render = None
+        self._bond = None
+        self._polyhedra = None
+        self._boundary = None
+        self._isosurface = None
+        self._lattice_plane = None
+        self._crystal_shape = None
+        self._molecular_surface = None
+        self._magres = None
+        self._cavity = None
+        #
         if from_ase or from_pymatgen or from_pybel:
             species, positions, attributes, cell, pbc, info = read_from_others(from_ase,
                                                                                from_pymatgen,
@@ -140,7 +151,7 @@ class Batoms(BaseCollection, ObjectGN):
             if species is None:
                 species = []
                 positions = []
-            self.set_collection(label)
+            self.set_collection(label, color_style=color_style, radius_style=radius_style)
             self._cell = Bcell(label, cell, batoms=self)
             positions = np.array(positions)
             if len(positions.shape) == 3:
@@ -167,33 +178,22 @@ class Batoms(BaseCollection, ObjectGN):
             if species_props is None:
                 species_props = species
             self._species = Bspecies(
-                label, label, species_props, self, segments=segments)
+                label, species_props, self, segments=segments)
             self.selects.add('all', np.arange(len(self)))
             if volume is not None:
                 self.build_volume(volume)
             self.set_pbc(pbc)
             # self.label = label
-            self.radius_style = radius_style
-            self.color_style = color_style
             if movie:
                 self.set_frames()
             self.show_unit_cell = show_unit_cell
             
         self.ribbon = Ribbon(self.label, batoms=self, datas=info, update=True)
-        self._render = None
-        self._bond = None
-        self._polyhedra = None
-        self._boundary = None
-        self._isosurface = None
-        self._lattice_plane = None
-        self._crystal_shape = None
-        self._molecular_surface = None
-        self._magres = None
-        self._cavity = None
         show_index()
         self.hideOneLevel()
 
-    def set_collection(self, label):
+    def set_collection(self, label, color_style='0',
+                        radius_style='0'):
         """Build main collection and its child collections.
 
         Args:
@@ -211,6 +211,9 @@ class Batoms(BaseCollection, ObjectGN):
             coll.children.link(subcoll)
         coll.batoms.type = 'BATOMS'
         coll.batoms.label = label
+        # set internal data
+        self.coll.batoms.color_style = str(color_style)
+        self.coll.batoms.radius_style = str(radius_style)
 
     def hideOneLevel(self):
         """Hide one level of collecitons in the outline in Blender
@@ -429,7 +432,7 @@ class Batoms(BaseCollection, ObjectGN):
         self.coll_name = label
         self.obj_name = label
         self._cell = Bcell(label=label, batoms = self)
-        self._species = Bspecies(label, label, {}, self)
+        self._species = Bspecies(label, {}, self)
         self._attributes = Attributes(label=label, parent=self, obj_name=self.obj_name)
         self.selects = Selects(label, self)
 

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -1982,3 +1982,28 @@ class Batoms(BaseCollection, ObjectGN):
             bpy.ops.export_scene.fbx(filepath=filename, use_selection=True)
         else:
             raise('File format %s is not supported.' % filename)
+
+    @property
+    def crystal_view(self):
+        return self.get_crystal_view()
+
+    @crystal_view.setter
+    def crystal_view(self, state):
+        self.set_crystal_view(state)
+
+    def get_crystal_view(self):
+        return self.coll.batoms.crystal_view
+
+    def set_crystal_view(self, crystal_view):
+        #
+        self.coll.batoms.crystal_view = crystal_view
+        if crystal_view:
+            self.boundary = 0.01
+            self.bond.show_search = True
+            self.bond.update()
+            self.polyhedra.update()
+        else:
+            self.boundary = 0
+            self.bond.show_search = False
+            self.bond.update()
+            self.polyhedra.update()

--- a/batoms/bond/search_bond.py
+++ b/batoms/bond/search_bond.py
@@ -309,6 +309,22 @@ class SearchBond(ObjectGN):
         gn.node_group.links.new(InstanceOnPoint.outputs['Instances'],
                                 JoinGeometry.inputs['Geometry'])
 
+    def update_geometry_node_instancer(self, spname, instancer):
+        """When instances are re-build, we need also update 
+        the geometry node.
+
+        Args:
+            spname (str): name of the species
+        """
+        from batoms.utils.butils import get_nodes_by_name
+        # update  instancers
+        ObjectInfo = get_nodes_by_name(self.gnodes.node_group.nodes,
+                                       'ObjectInfo_%s_%s' % (
+                                           self.label, spname),
+                                       'GeometryNodeObjectInfo')
+        ObjectInfo.inputs['Object'].default_value = instancer
+        logger.debug('update boundary instancer: {}'.format(spname))
+        
     @property
     def obj_o(self):
         return self.get_obj_o()

--- a/batoms/bond/setting.py
+++ b/batoms/bond/setting.py
@@ -567,10 +567,11 @@ class BondSettings(Setting):
         Args:
             key (str): _description_
         """
+        species_props0 = self.batoms.species.species_props
         species_props = {}
         for sp in key:
             if sp in self.batoms.species.keys():
-                species_props[sp] = self.batoms.species.species_props[sp]
+                species_props[sp] = species_props0[sp]
         if value:
             species_props.update(value)
         bond = self.get_bondtable(key, species_props, dcutoff=0.5)

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -359,6 +359,22 @@ class Boundary(ObjectGN):
         # self.batoms.draw()
         logger.debug('update boundary: {0:10.2f} s'.format(time() - tstart))
 
+    def update_geometry_node_instancer(self, spname, instancer):
+        """When instances are re-build, we need also update 
+        the geometry node.
+
+        Args:
+            spname (str): name of the species
+        """
+        from batoms.utils.butils import get_nodes_by_name
+        # update  instancers
+        ObjectInfo = get_nodes_by_name(self.gnodes.node_group.nodes,
+                                       'ObjectInfo_%s_%s' % (
+                                           self.label, spname),
+                                       'GeometryNodeObjectInfo')
+        ObjectInfo.inputs['Object'].default_value = instancer
+        logger.debug('update boundary instancer: {}'.format(spname))
+
     @property
     def obj(self):
         return self.get_obj()

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -327,7 +327,7 @@ class Species(BaseObject):
                 node.inputs['Base Color'].default_value = color
             if 'Alpha' in node.inputs:
                 node.inputs['Alpha'].default_value = color[3]
-        self.data.elements[self.main_element].color = color
+        # self.data.elements[self.main_element].color = color
         self.data.color = color
 
     @property

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -50,8 +50,12 @@ class Batoms_PT_prepare(Panel):
         layout.label(text="Polyhedra style")
         layout.prop(batoms, "polyhedra_style", expand=True)
 
-        layout.prop(batoms, "show", expand=True)
-        layout.prop(batoms, "wrap", expand=True)
+        split = layout.split()
+        col = split.column()
+        col.prop(batoms, "show", expand=True)
+        col = split.column()
+        col.prop(batoms, "wrap", expand=True)
+        layout.prop(batoms, "crystal_view", expand=True)
         layout.prop(batoms, "show_label", expand=True, text="label")
         layout.prop(batoms, "scale")
 
@@ -243,6 +247,13 @@ class BatomsProperties(bpy.types.PropertyGroup):
                        description="wrap all atoms into cell",
                        get=get_wrap,
                        set=set_attr("wrap", set_batoms_attr)
+                       )
+
+    crystal_view: BoolProperty(name="crystal_view",
+                       default=False,
+                       description="crystal_view all object for view and rendering",
+                       get=get_attr("crystal_view", get_active_collection),
+                       set=set_attr("crystal_view", set_batoms_attr)
                        )
 
     scale: FloatProperty(

--- a/batoms/gui/ui_list_species.py
+++ b/batoms/gui/ui_list_species.py
@@ -59,7 +59,7 @@ class BATOMS_PT_species(Panel):
         ob = context.object
         ba = bpy.data.collections[ob.batoms.label].batoms
         if len(ba.settings_species) > 0:
-            kb = ba.settings_species[ba.ui_list_index_select]
+            kb = ba.settings_species[ba.ui_list_index_species]
         else:
             kb = None
 
@@ -70,7 +70,7 @@ class BATOMS_PT_species(Panel):
             rows = 5
 
         row.template_list("BATOMS_UL_species", "", ba,
-                          "settings_species", ba, "ui_list_index_select", rows=rows)
+                          "settings_species", ba, "ui_list_index_species", rows=rows)
 
         col = row.column(align=True)
         op = col.operator("batoms.species_add", icon='ADD', text="")

--- a/batoms/internal_data/bpy_data.py
+++ b/batoms/internal_data/bpy_data.py
@@ -345,6 +345,7 @@ class BatomsCollection(bpy.types.PropertyGroup):
                              False, False, False], size=3)
     boundary: PointerProperty(name="Bboundary", type=Bboundary)
     cell: PointerProperty(name='Bcell', type=Bcell)
+    crystal_view: BoolProperty(name="crystal_view", default=False)
     ui_list_index_species: IntProperty(name="ui_list_index_species",
                                default=0)
     ui_list_index_select: IntProperty(name="ui_list_index_select",

--- a/batoms/internal_data/bpy_data.py
+++ b/batoms/internal_data/bpy_data.py
@@ -185,7 +185,7 @@ class Bcell(bpy.types.PropertyGroup):
     color: FloatVectorProperty(name="color", size=4,
                                subtype='COLOR',
                                min=0, max=1,
-                               default=[0, 0, 0, 1])
+                               default=[0.2, 0.2, 0.2, 1])
 
 class Bvolume(bpy.types.PropertyGroup):
     """

--- a/batoms/preferences.py
+++ b/batoms/preferences.py
@@ -66,7 +66,7 @@ def set_plugin(key):
     def setter(self, value):
         import importlib
         self[key] = value
-        plugin = importlib.import_module("batoms.{}".format(key))
+        plugin = importlib.import_module("batoms.plugins.{}".format(key))
         if value:
             plugin.register_class()
             logger.info("Enable {} plugin.".format(key))
@@ -299,15 +299,17 @@ class BatomsAddonPreferences(AddonPreferences):
                 box.prop(self, modname, text=package)
         #
         layout.separator()
-        box = layout.box().column()
-        box.label(text="Custom Plugins")
-        box.prop(self, "isosurface")
-        box.prop(self, "molecular_surface")
-        box.prop(self, "crystal_shape")
-        box.prop(self, "lattice_plane")
-        box.prop(self, "cavity")
-        box.prop(self, "magres")
-        box.prop(self, "real_interaction")
+        split = layout.split()
+        col = split.column()
+        col.label(text="Custom Plugins")
+        col.prop(self, "isosurface")
+        col.prop(self, "molecular_surface")
+        col.prop(self, "crystal_shape")
+        col.prop(self, "lattice_plane")
+        col.prop(self, "cavity")
+        col.prop(self, "magres")
+        col.prop(self, "real_interaction")
+        col = split.column()
         # custom folder
         layout.separator()
         box = layout.box().column()

--- a/batoms/utils/__init__.py
+++ b/batoms/utils/__init__.py
@@ -147,13 +147,27 @@ def default_element_prop(element, radius_style='covalent',
 
 def get_default_species_data(elements, radius_style='covalent',
                              color_style="JMOL", props={}):
-    """
-    Set default color, radii for elements,
-    Todo fraction occupancy
+    """Set default color, radii for elements,
+
+    Args:
+        elements (dict): _description_
+        radius_style (str, optional): _description_. Defaults to 'covalent'.
+        color_style (str, optional): _description_. Defaults to "JMOL".
+        props (dict, optional): _description_. Defaults to {}.
+
+    exmaples:
+    elements = {"Fe": 0.8, "Cr": 0.2}
+    elements = {"Fe": {"occupancy": 0.8}, "Cr": {"occupancy": 0.2}}
+
+    Returns:
+        _type_: _description_
     """
     radius = 0
     species_props = {"elements": {}}
     for ele, eledata in elements.items():
+        if isinstance(eledata, (int, float)):
+            # only has occupancy data
+            eledata = {"occupancy": eledata}
         species_props["elements"][ele] = eledata
         data = default_element_prop(ele, radius_style=radius_style,
                                     color_style=color_style)

--- a/tests/test_bond.py
+++ b/tests/test_bond.py
@@ -4,6 +4,7 @@ from batoms.batoms import Batoms
 from ase.build import molecule, bulk
 from batoms.bio.bio import read
 from time import time
+import numpy as np
 
 try:
     from _common_helpers import has_display, set_cycles_res
@@ -25,12 +26,25 @@ def test_bond():
     c2h6so.show = [0, 0, 1, 1, 1, 1, 1, 1, 1, 1]
     c2h6so.model_style = 1
     c2h6so.bond[0].order = 2
-    c2h6so.bond.settings["C-H"].color1 = [0, 1, 0, 1]
-    c2h6so.bond.settings["C-H"].color2 = [0, 1, 1, 1]
     c2h6so.bond.settings["C-H"].order = 2
     c2h6so.model_style = 1
     c2h6so.bond[0].order = 2
 
+def test_color():
+    bpy.ops.batoms.delete()
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.molecule_add(label="c2h6so", formula="C2H6SO")
+    c2h6so = Batoms("c2h6so")
+    c2h6so.model_style = 1
+    assert np.isclose(c2h6so.bond.settings.\
+        instancers['C-H']['1_1'].data.materials[1].\
+            diffuse_color[:], np.array([1, 1, 1, 1])).all()
+    c2h6so.bond.settings["C-H"].color1 = [0, 1, 0, 1]
+    c2h6so.bond.settings["C-H"].color2 = [0, 1, 1, 1]
+    assert np.isclose(c2h6so.bond.settings.\
+        instancers['C-H']['1_1'].data.materials[1].\
+            diffuse_color[:], np.array([0, 1, 1, 1])).all()
+    
 
 def test_bond_high_order():
     from ase.build import molecule, bulk
@@ -72,7 +86,7 @@ def test_bond_search_bond_0():
     from batoms.bio.bio import read
     bpy.ops.batoms.delete()
     tio2 = read("../tests/datas/tio2.cif")
-    tio2.bond.settings[('Ti', 'O')].search = 0
+    tio2.bond.settings[("Ti", "O")].search = 0
     tio2.model_style = 1
     tio2.boundary = 0.01
     tio2.model_style = 1

--- a/tests/test_preference.py
+++ b/tests/test_preference.py
@@ -10,6 +10,16 @@ addon = bpy.context.preferences.addons[package]
 preferences = addon.preferences
 
 
+def test_enable_disable_plugin():
+    from bpy.types import Collection, Object
+    assert preferences.magres==True
+    assert hasattr(Collection, 'Bmagres')
+    preferences.magres=False
+    assert not hasattr(Collection, 'Bmagres')
+    preferences.magres=True
+    assert hasattr(Collection, 'Bmagres')
+
+
 def create_molecule():
     bpy.ops.batoms.delete()
     from batoms import Batoms

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -61,8 +61,27 @@ def test_auto_build_species():
     assert len(magnetite.bonds.setting) == 10
     assert len(magnetite.polyhedras.setting) == 3
 
+def test_geometry_node_object():
+    """species instances are used in geometry node,
+    in batoms, boundary, search_bond. When instances are 
+    re-build, we need also update the geometry node."""
+    from batoms.bio.bio import read
+    bpy.ops.batoms.delete()
+    tio2 = read("../tests/datas/tio2.cif")
+    tio2.boundary = 0.01
+    tio2.bond.show_search = True
+    tio2.model_style = 1
+    tio2.species["Ti"].color = [1, 1, 0, 1]
+    tio2.species.update()
+    assert tio2.gnodes.node_group.nodes['ObjectInfo_tio2_Ti'].inputs['Object'].default_value is not None
+    assert tio2.boundary.gnodes.node_group.nodes['ObjectInfo_tio2_Ti'].inputs['Object'].default_value is not None
+    assert tio2.bond.search_bond.gnodes.node_group.nodes['ObjectInfo_tio2_Ti'].inputs['Object'].default_value is not None
+
+
 
 if __name__ == "__main__":
     test_batoms_species()
     test_species_color()
+    test_geometry_node_object()
     test_auto_build_species()
+    print("\n Batoms: All pass! \n")


### PR DESCRIPTION
Fix three bugs:

- Geometry Node
  When updating species, the instances are deleted and re-created. Therefore, we have to update the Geometry Node which uses these instances as object inputs. They are `batoms`, `boundary` and `search_bond`.

- Color
   The color of a species is initialized by its elements. After that, the color of the main element is not used, instead, the color of the species is used for the color of the main element. Then, the ui_list_species panel works well.

- wrong path when importing plugins in preference

New feature:

- add `crystal_view` in `gui_batoms`


Enhancement:

- add test for enabling and disabling plugins in preference