### PR TITLE
Fix segments

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -2001,3 +2001,23 @@ class Batoms(BaseCollection, ObjectGN):
             self.bond.show_search = False
             self.bond.update()
             self.polyhedra.update()
+    
+    @property
+    def segments(self):
+        return self.get_segments()
+
+    @segments.setter
+    def segments(self, segments):
+        self.set_segments(segments)
+
+    def get_segments(self):
+        return self.coll.batoms.segments[:]
+
+    def set_segments(self, segments):
+        if isinstance(segments, int):
+            segments = [segments, segments]
+            # raise Exception('Segments should be int!')
+        species = self._species
+        for name, sp in species.items():
+            sp.data.segments = segments
+            sp.update(sp.data.as_dict())

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -2018,6 +2018,7 @@ class Batoms(BaseCollection, ObjectGN):
             segments = [segments, segments]
             # raise Exception('Segments should be int!')
         species = self._species
+        self.coll.batoms.segments = segments
         for name, sp in species.items():
             sp.data.segments = segments
             sp.update(sp.data.as_dict())

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -372,14 +372,14 @@ class Species(BaseObject):
         self.set_segments(segments)
 
     def get_segments(self):
-        nverts = len(self.instancer.data.vertices)
-        return nverts
+        return self.data.segmetns[:]
 
     def set_segments(self, segments):
-        if not isinstance(segments, int):
-            raise Exception('Segments should be int!')
-        self._species.update(segments=segments)
-        self.build_geometry_node()
+        if isinstance(segments, int):
+            segments = [segments, segments]
+            # raise Exception('Segments should be int!')
+        self.data.segments = segments
+        self.update(self.data.as_dict())
 
     def as_dict(self) -> dict:
         data = {

--- a/batoms/console.py
+++ b/batoms/console.py
@@ -1,6 +1,10 @@
 import bpy
 import console_python
 from batoms.batoms import Batoms
+import logging
+# logger = logging.getLogger('batoms')
+logger = logging.getLogger(__name__)
+
 
 def console_hook():
     """add batoms to namespace of python console
@@ -18,8 +22,12 @@ def console_hook():
                         item = item.replace('.', '')
                         if item[:1].isdigit():
                             item = 'b_' + item
+                        console.push("from batoms import Batoms")
                         if item not in console.locals:
-                            console.locals[item] = Batoms(item)
+                            logger.info("Python console: Add Batoms {}".format(item))
+                            console.push("{}=Batoms('{}')".format(item, item))
+                            console.push("".format(item))
+                            # console.locals[item] = Batoms(item)
 
 
 def register_hook():

--- a/batoms/internal_data/bpy_data.py
+++ b/batoms/internal_data/bpy_data.py
@@ -335,6 +335,7 @@ class BatomsCollection(bpy.types.PropertyGroup):
                ('3', "polyhedra", "polyhedra")),
         default='0')
 
+    segments: IntVectorProperty(name="segments", size=2, default=(24, 16))
     scale: FloatProperty(name="scale", default=1)
     show: BoolProperty(name="show", default=True)
     show_unit_cell: BoolProperty(name="show_unit_cell", default=True)

--- a/batoms/polyhedra/polyhedra.py
+++ b/batoms/polyhedra/polyhedra.py
@@ -165,7 +165,7 @@ class Polyhedra(ObjectGN):
         self.set_frames(self._frames, only_basis=True)
         # self.assign_materials()
         self.update_geometry_node_material()
-        obj.parent = self.batoms.obj
+        obj.parent = self.obj
         logger.debug('polyhedras: build_object: {0:10.2f} s'.format(time() - tstart))
 
     def assign_materials(self):

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -69,6 +69,10 @@ def test_batoms_parameters():
     )
     assert h2o.model_style == 1
     assert np.isclose(h2o.scale, 0.5)
+    # segments
+    assert h2o.segments[0] == 24
+    h2o.segments = [6, 6]
+    assert h2o.segments[0] == 6
 
 
 def test_model_style():


### PR DESCRIPTION

`segments`, default is [24, 16], controls the resolution of the sphere used to represent the atoms. For large systems with hundreds of thousands of atoms, small values ([6, 6]) are suggested for `segments`.

`segments` in `Batoms` control segments of all species.
```python
CH4.segments = [6, 6]
```
`segments` in `Species` control segments of that species.
```python
CH4.species['C'].segments = [6, 6]
```