### PR TITLE
add scale parameter for cavity

### DIFF
--- a/batoms/ops/ops_batoms.py
+++ b/batoms/ops/ops_batoms.py
@@ -452,8 +452,7 @@ class BatomModify(OperatorBatomsEdit):
         obj = context.object
         v = get_selected_vertices(obj)
         batoms = Batoms(label=obj.batoms.label)
-        for i in v:
-            setattr(batoms[i], self.key, getattr(self, self.key))
+        setattr(batoms[v], self.key, getattr(self, self.key))
         context.view_layer.objects.active = obj
         bpy.ops.object.mode_set(mode="EDIT")
         return {'FINISHED'}

--- a/batoms/plugins/cavity/bpy_data.py
+++ b/batoms/plugins/cavity/bpy_data.py
@@ -19,6 +19,7 @@ class CavitySetting(Base):
     label: StringProperty(name="label", default='')
     min: FloatProperty(name="min", default=5)
     max: FloatProperty(name="max", default=6)
+    scale: FloatProperty(name="scale", default=1.0)
     resolution: FloatProperty(name="resolution", soft_min=0.5, soft_max=2,
                               default=1.0)
     color: FloatVectorProperty(name="color", size=4,
@@ -32,6 +33,7 @@ class CavitySetting(Base):
             'flag': self.flag,
             'min': self.min,
             'max': self.max,
+            'scale': self.scale,
             'name': self.name,
             'material_style': self.material_style,
             'color': self.color[:],

--- a/batoms/plugins/cavity/cavity.py
+++ b/batoms/plugins/cavity/cavity.py
@@ -184,15 +184,18 @@ class Cavity(ObjectGN):
                     ic = 0
         species_index = np.zeros(ns, dtype = int)
         show = np.ones(ns, dtype=int)
+        scale = np.ones(ns, dtype=int)
         ncollection = len(self.settings.bpy_setting)
         for i in range(ncollection):
             cav = self.settings.bpy_setting[i]
             indices = np.where((spheres['radii'] > cav.min) & (
                 spheres['radii'] < cav.max))[0]
             species_index[indices] = string2Number(cav.name)
+            scale[indices] = spheres['radii'][indices]*cav.scale
+        logger.debug(scale)
         spheres.update({'centers': np.array([spheres['centers']]),
                         'species_index': species_index,
-                        'scale': spheres['radii'],
+                        'scale': scale,
                         'show': show})
         return spheres
 

--- a/batoms/plugins/cavity/setting.py
+++ b/batoms/plugins/cavity/setting.py
@@ -57,9 +57,10 @@ class CavitySettings(Setting):
 
     def __repr__(self) -> str:
         s = "-"*60 + "\n"
-        s = "Name     min   max              color  \n"
+        s = "Name       min   max   scale                color  \n"
         for cav in self.bpy_setting:
-            s += "{:10s}   {:1.6f}   {:1.6f}".format(cav.name, cav.min, cav.max)
+            s += "{:4s}   {:1.3f}   {:1.3f}   {:1.3f}   " \
+                .format(cav.name, cav.min, cav.max, cav.scale)
             s += "[{:1.2f}  {:1.2f}  {:1.2f}  {:1.2f}] \n".format(
                 cav.color[0], cav.color[1], cav.color[2], cav.color[3])
         s += "-"*60 + "\n"

--- a/batoms/plugins/cavity/ui_list.py
+++ b/batoms/plugins/cavity/ui_list.py
@@ -104,6 +104,7 @@ class BATOMS_PT_cavity(Panel):
             sub = col.column(align=True)
             sub.prop(kb, "min", text="min")
             sub.prop(kb, "max", text="max")
+            sub.prop(kb, "scale", text="scale")
             sub.prop(kb, "material_style", text="material_style")
             col.prop(kb, "color",  text="color")
             col.separator()


### PR DESCRIPTION

One user asks to add a feature to change the size of the sphere.

In this PR, we add a `scale` keyword. 

```python
>>> mof.cavity.settings
Name       min   max   scale                color
0      7.000   8.000   1.000   [1.00  0.00  0.00  1.00]
1      5.000   6.000   1.000   [0.00  1.00  0.00  1.00]
------------------------------------------------------------
>>> # change the size of `0` by half of the original.
>>> mof.cavity.settings['0'].scale = 0.5
```