### PR TITLE
export batoms to dict

### DIFF
--- a/batoms/base/collection.py
+++ b/batoms/base/collection.py
@@ -229,7 +229,7 @@ class Setting():
         """
         data = {}
         for b in self.bpy_setting:
-            data[b.name] = b
+            data[b.name] = b.as_dict()
         return data
 
     def __getitem__(self, key):

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -454,7 +454,7 @@ class Batoms(BaseCollection, ObjectGN):
         """
         """
         data = {
-            'batoms': {},
+            'batoms': {'label': self.label},
             'cell': None,
             'bond': {},
             'polyhedra': {},
@@ -462,8 +462,8 @@ class Batoms(BaseCollection, ObjectGN):
         }
         data['batoms']['array'] = dict(self.arrays)
         data['batoms']['species'] = self.species.as_dict()
-        data['cell'] = np.asarray(self.cell)
-        data['pbc'] = self.pbc
+        data['batoms'].update(self.coll.batoms.as_dict())
+        data['cell'] = self.cell.as_dict()
         data['bond'] = self.bond.as_dict()
         data['polyhedra'] = self.polyhedra.as_dict()
         data['boundary'] = self.boundary.as_dict()

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -435,6 +435,39 @@ class Batoms(BaseCollection, ObjectGN):
         self._species = Bspecies(label, {}, self)
         self._attributes = Attributes(label=label, parent=self, obj_name=self.obj_name)
         self.selects = Selects(label, self)
+    
+    @classmethod
+    def from_dict(cls, data):
+        """Build batoms object from a dictionary.
+
+        Args:
+            data (dict): _description_
+
+
+        Returns:
+            Batoms: _description_
+
+        """
+        pass
+
+    def as_dict(self):
+        """
+        """
+        data = {
+            'batoms': {},
+            'cell': None,
+            'bond': {},
+            'polyhedra': {},
+            'boundary': {},
+        }
+        data['batoms']['array'] = dict(self.arrays)
+        data['batoms']['species'] = self.species.as_dict()
+        data['cell'] = np.asarray(self.cell)
+        data['pbc'] = self.pbc
+        data['bond'] = self.bond.as_dict()
+        data['polyhedra'] = self.polyhedra.as_dict()
+        data['boundary'] = self.boundary.as_dict()
+        return data
 
     @property
     def volume(self):

--- a/batoms/bond/bond.py
+++ b/batoms/bond/bond.py
@@ -1544,3 +1544,16 @@ class Bond(BaseCollection, ObjectGN):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
+    
+    def as_dict(self):
+        """
+        """
+        data = {
+            'array': None
+        }
+        if len(self) > 1:
+            data['array'] = dict(self.arrays)
+        data['show_search'] = self.show_search
+        data['show_hydrogen_bond'] = self.show_hydrogen_bond
+        data['settings'] = self.settings.as_dict()
+        return data

--- a/batoms/boundary.py
+++ b/batoms/boundary.py
@@ -646,8 +646,16 @@ class Boundary(ObjectGN):
         s = self.boundary.__repr__()
         return s
 
-
-
+    def as_dict(self):
+        """
+        """
+        data = {
+            'array': None
+        }
+        if len(self) > 1:
+            data['array'] = dict(self.arrays)
+        data['boundary'] = self.boundary
+        return data
 
 def search_boundary(atoms,
                     boundary=[[0, 1], [0, 1], [0, 1]],
@@ -710,4 +718,3 @@ def search_boundary(atoms,
     offsets_b = offsets[ind1]
     # print('search boundary: {0:10.2f} s'.format(time() - tstart))
     return offsets_b
-

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -153,6 +153,7 @@ class Species(BaseObject):
                                   material_style=material_style,
                                   backface_culling=True)
             mesh.materials.append(mat)
+            self.parent.batoms.obj.data.materials.append(mat)
             i += 1
 
     def assign_materials(self):
@@ -629,3 +630,10 @@ class Bspecies(Setting):
             self.segments = segments
         for name, sp in self.species.items():
             sp.build_instancer()
+
+    def as_dict(self) -> dict:
+        species = self.species
+        data = {}
+        for name, sp in species.items():
+            data[name] = sp.as_dict()
+        return data

--- a/batoms/cell.py
+++ b/batoms/cell.py
@@ -421,3 +421,12 @@ class Bcell(ObjectGN):
         from batoms.utils import deprecated
         deprecated('"draw" will be deprecated in the furture. The cell is drawn automaticely now.')
         pass
+
+    def as_dict(self):
+        """
+        """
+        data = {
+            'array': self.array,
+        }
+        data.update(self.batoms.coll.batoms.cell.as_dict())
+        return data

--- a/batoms/internal_data/bpy_data.py
+++ b/batoms/internal_data/bpy_data.py
@@ -185,6 +185,14 @@ class Bcell(bpy.types.PropertyGroup):
                                subtype='COLOR',
                                min=0, max=1,
                                default=[0.2, 0.2, 0.2, 1])
+    
+    def as_dict(self) -> dict:
+        setdict = {
+            'pbc': self.pbc,
+            'width': self.width,
+            'color': self.color[:],
+        }
+        return setdict
 
 class Bvolume(bpy.types.PropertyGroup):
     """
@@ -357,7 +365,20 @@ class BatomsCollection(bpy.types.PropertyGroup):
     settings_species: CollectionProperty(name='settings_species',
                                  type=Bspecies)
 
-    
+    def as_dict(self) -> dict:
+        setdict = {
+            'model_style': self.model_style,
+            'color_style': self.color_style,
+            'radius_style': self.radius_style,
+            'polyhedra_style': self.polyhedra_style,
+            'segments': self.segments,
+            'wrap': self.wrap,
+            'show_axes': self.show_axes,
+            'show_label': self.show_label,
+            'crystal_view': self.crystal_view,
+            'scale': self.scale,
+        }
+        return setdict
 
 class BatomsObject(bpy.types.PropertyGroup):
     label: StringProperty(name="label", default='batoms')

--- a/batoms/plugins/__init__.py
+++ b/batoms/plugins/__init__.py
@@ -1,24 +1,44 @@
 import bpy
 import importlib
 
-plugins = [
-    'isosurface',
-    'molecular_surface',
-    'lattice_plane',
-    'crystal_shape',
-    'cavity',
-    'magres',
-    'real_interaction',
-]
+
+"""
+import pathlib
+import os
+from time import time
+cwd = os.path.dirname(pathlib.Path(__file__))
+plugin_folders = []
+
+tstart = time()
+for f in os.listdir(cwd):
+     if os.path.isdir(os.path.join(cwd, f)) and f != '__pycache__':
+         plugin_folders.append(f)
+
+plugin_info = {}
+for name in plugin_folders:
+    info = getattr(importlib.import_module("batoms.plugins.{}".format(name)), 'plugin_info')
+    plugin_info[name] = info
+print("Read plugin info: {:1.2f}".format(time() - tstart))
+"""
+
+
+plugin_info = {
+    'cavity': ['cavity', 'Cavity', 'Bcavity'],
+    'crystal_shape': ['crystal_shape', 'CrystalShape', 'Bcrystalshape'],
+    'lattice_plane': ['lattice_plane', 'LatticePlane', 'Blatticeplane'],
+    'isosurface': ['isosurface', 'Isosurface', 'Bisosurface'],
+    'molecular_surface': ['molecular_surface', 'MolecularSurface', 'Bmolecularsurface'],
+    'magres': ['magres', 'Magres', 'Bmagres'],
+    }
 
 def enable_plugin():
-    for key in plugins:
+    for key in plugin_info.keys():
         if getattr(bpy.context.preferences.addons['batoms'].preferences, key):    
             plugin = importlib.import_module("batoms.plugins.{}".format(key))
             plugin.register_class()   
 
 def disable_plugin():
-    for key in plugins:
+    for key in plugin_info.keys():
         if getattr(bpy.context.preferences.addons['batoms'].preferences, key):    
             plugin = importlib.import_module("batoms.plugins.{}".format(key))
             plugin.unregister_class()   

--- a/batoms/plugins/cavity/bpy_data.py
+++ b/batoms/plugins/cavity/bpy_data.py
@@ -53,8 +53,15 @@ class Cavity(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='CavitySetting',
                                 type=CavitySetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/cavity/cavity.py
+++ b/batoms/plugins/cavity/cavity.py
@@ -62,7 +62,9 @@ class Cavity(ObjectGN):
         self.resolution = resolution
         self.minRadius = mimRadius
         flag = self.load()
-        if not flag and cavity_datas is not None:
+        if not flag:
+            if cavity_datas is None:
+                cavity_datas = default_cavity_datas
             self.build_object(cavity_datas)
             self.settings = CavitySettings(
                 self.label, batoms=batoms, parent=self)
@@ -70,6 +72,7 @@ class Cavity(ObjectGN):
             self.settings = CavitySettings(
                 self.label, batoms=batoms, parent=self)
             self._attributes = Attributes(label=self.label, parent=self, obj_name=self.obj_name)
+        self.settings.bpy_data.active = True
 
     def build_materials(self, name, color, node_inputs=None,
                         material_style='default'):
@@ -469,3 +472,11 @@ class Cavity(ObjectGN):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
+    
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/plugins/crystal_shape/bpy_data.py
+++ b/batoms/plugins/crystal_shape/bpy_data.py
@@ -73,8 +73,15 @@ class CrystalShape(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='CrystalShapeSetting',
                                 type=CrystalShapeSetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+    
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/crystal_shape/crystal_shape.py
+++ b/batoms/plugins/crystal_shape/crystal_shape.py
@@ -32,6 +32,7 @@ class CrystalShape(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = CrystalShapeSettings(
             self.label,  parent=self)
+        self.settings.bpy_data.active = True
 
     def build_materials(self, name, color, node_inputs=None,
                         material_style='default'):
@@ -298,3 +299,11 @@ def convexhull(planes, point):
         if abs(x1) > 1e-6 and x1*x2 < -1e-6:
             return None
     return point
+
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/plugins/isosurface/bpy_data.py
+++ b/batoms/plugins/isosurface/bpy_data.py
@@ -49,8 +49,16 @@ class Isosurface(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='IsosurfaceSetting',
                                 type=IsosurfaceSetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict
+        

--- a/batoms/plugins/isosurface/isosurface.py
+++ b/batoms/plugins/isosurface/isosurface.py
@@ -34,6 +34,7 @@ class Isosurface(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = IsosurfaceSettings(
             self.label, batoms=batoms, parent=self)
+        self.settings.bpy_data.active = True
 
     def build_isosurface(self, cell):
         volume = self.batoms.volume
@@ -132,3 +133,11 @@ def calc_isosurface(volume, cell, level,
     scaled_verts -= cell_origin
     faces = list(faces)
     return scaled_verts, faces
+
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/plugins/lattice_plane/bpy_data.py
+++ b/batoms/plugins/lattice_plane/bpy_data.py
@@ -73,8 +73,15 @@ class LatticePlane(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='LatticePlaneSetting',
                                 type=LatticePlaneSetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/lattice_plane/lattice_plane.py
+++ b/batoms/plugins/lattice_plane/lattice_plane.py
@@ -36,6 +36,7 @@ class LatticePlane(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = LatticePlaneSettings(
             self.label, parent=self)
+        self.settings.bpy_data.active = True
 
     def build_materials(self, name, color, node_inputs=None,
                         material_style='default'):
@@ -338,7 +339,15 @@ class LatticePlane(BaseObject):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
-        
+    
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data
+
 def save_image(data, filename, interpolation='bicubic'):
     """
     """

--- a/batoms/plugins/magres/bpy_data.py
+++ b/batoms/plugins/magres/bpy_data.py
@@ -62,8 +62,15 @@ class Magres(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='MagresSetting',
                                 type=MagresSetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/magres/magres.py
+++ b/batoms/plugins/magres/magres.py
@@ -37,6 +37,7 @@ class Magres(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = MagresSettings(
             self.label, parent=self)
+        self.settings.bpy_data.active = True
 
     def build_materials(self, name, color, node_inputs=None,
                         material_style='default'):
@@ -177,3 +178,11 @@ class Magres(BaseObject):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
+    
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/plugins/molecular_surface/bpy_data.py
+++ b/batoms/plugins/molecular_surface/bpy_data.py
@@ -61,8 +61,15 @@ class MolecularSurface(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     settings: CollectionProperty(name='MolecularSurfaceSetting',
                                 type=MolecularSurfaceSetting)
 
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/molecular_surface/molecular_surface.py
+++ b/batoms/plugins/molecular_surface/molecular_surface.py
@@ -35,6 +35,7 @@ class MolecularSurface(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = MolecularSurfaceSettings(
             self.label, parent=self)
+        self.settings.bpy_data.active = True
 
     def build_materials(self, name, color, node_inputs=None,
                         material_style='default'):
@@ -807,3 +808,11 @@ class MolecularSurface(BaseObject):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
+    
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/plugins/template/bpy_data.py
+++ b/batoms/plugins/template/bpy_data.py
@@ -37,8 +37,15 @@ class Template(bpy.types.PropertyGroup):
     Blender’s internal data.
 
     """
+    active: BoolProperty(name="active", default=False)
     show: BoolProperty(name="show", default=True)
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)
     settings: CollectionProperty(name='TemplateSetting',
                                 type=TemplateSetting)
+
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/plugins/template/template.py
+++ b/batoms/plugins/template/template.py
@@ -33,6 +33,7 @@ class Template(BaseObject):
         BaseObject.__init__(self, label, name)
         self.settings = TemplateSettings(
             self.label, parent=self)
+        self.settings.bpy_data.active = True
     
     def build_materials(self, name, color,
                         node_inputs=None,
@@ -93,3 +94,10 @@ class Template(BaseObject):
     def mat(self):
         return bpy.data.materials.get(self.name)
    
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data

--- a/batoms/polyhedra/bpy_data.py
+++ b/batoms/polyhedra/bpy_data.py
@@ -61,3 +61,8 @@ class Polyhedra(Base):
     settings: CollectionProperty(name='polyhedrasetting',
                               type=PolyhedraSetting)
     
+    def as_dict(self) -> dict:
+        setdict = {
+            
+        }
+        return setdict

--- a/batoms/polyhedra/polyhedra.py
+++ b/batoms/polyhedra/polyhedra.py
@@ -638,3 +638,14 @@ class Polyhedra(ObjectGN):
         """setting object."""
         deprecated('"setting" will be deprecated in the furture, please use "settings".')
         return self.settings
+    
+    def as_dict(self):
+        """
+        """
+        data = {
+            'array': None
+        }
+        if len(self) > 1:
+            data['array'] = dict(self.arrays)
+        data['settings'] = self.settings.as_dict()
+        return data

--- a/batoms/preferences.py
+++ b/batoms/preferences.py
@@ -265,6 +265,14 @@ class BatomsAddonPreferences(AddonPreferences):
         default=True,
     )
 
+    template: BoolProperty(
+        name="template",
+        description="Enable template plugin",
+        get=get_plugin("template"),
+        set=set_plugin("template"),
+        default=True,
+    )
+
     def draw(self, context):
 
         layout = self.layout
@@ -309,6 +317,7 @@ class BatomsAddonPreferences(AddonPreferences):
         col.prop(self, "cavity")
         col.prop(self, "magres")
         col.prop(self, "real_interaction")
+        col.prop(self, "template")
         col = split.column()
         # custom folder
         layout.separator()

--- a/tests/test_batoms.py
+++ b/tests/test_batoms.py
@@ -367,6 +367,19 @@ def test_make_real():
     h2o.realize_instances = True
     h2o.realize_instances = False
 
+def test_as_dict():
+    from batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(label='au', formula = 'Au')
+    au = Batoms("au")
+    data = au.as_dict()
+    assert 'lattice_plane' not in data.keys()
+    # active plugin
+    au.lattice_plane
+    data = au.as_dict()
+    assert 'lattice_plane' in data.keys()
+
+
 
 @pytest.mark.skipif(
     blender31,


### PR DESCRIPTION
In this PR, I added `as_dict()` function to export the  `Batoms` and its submodules to a dictionary.

@alchem0x2A I keep the import function `from_dict()` empty till now, because I think it is related to the new design of `batoms_api`.