### PR TITLE
add main panel for each plugin

### DIFF
--- a/batoms/base/object.py
+++ b/batoms/base/object.py
@@ -19,9 +19,9 @@ default_object_datas = {
 
 class BaseObject():
 
-    def __init__(self, obj_name, bobj_name="batoms"):
+    def __init__(self, obj_name, btype="batoms"):
         self.obj_name = obj_name
-        self.bobj_name = bobj_name
+        self.btype = btype
 
     @property
     def obj(self):
@@ -34,12 +34,12 @@ class BaseObject():
         return obj
 
     @property
-    def bobj(self):
-        return self.get_bobj()
+    def bpy_data(self):
+        return self.get_bpy_data()
 
-    def get_bobj(self):
-        bobj = getattr(self.obj, self.bobj_name)
-        return bobj
+    def get_bpy_data(self):
+        bpy_data = getattr(self.obj, self.btype)
+        return bpy_data
 
     @property
     def location(self):
@@ -115,10 +115,10 @@ class BaseObject():
         self.set_look_at(look_at)
 
     def get_look_at(self):
-        return np.array(self.bobj.look_at)
+        return np.array(self.bpy_data.look_at)
 
     def set_look_at(self, look_at):
-        self.bobj.look_at = look_at
+        self.bpy_data.look_at = look_at
         set_look_at(self.obj, look_at, roll=0.0)
 
     def translate(self, displacement):

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -19,7 +19,7 @@ class Species(BaseObject):
         self.label = parent.label
         self.coll_name = "%s_instancer" % (self.label)
         BaseObject.__init__(self, obj_name="%s_%s" % (self.label, name),
-                            bobj_name="binstancer")
+                            btype="binstancer")
         if data is not None:
             self.update(data)
 

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -127,7 +127,7 @@ def get_enum_attr(name, func):
     return getter
 
 
-def set_enum_attr(name):
+def set_enum_attr(name, func):
     """Helper function to easily set enum property.
 
     Args:
@@ -139,7 +139,7 @@ def set_enum_attr(name):
         item = items[value]
         identifier = item.identifier
         self[name] = identifier
-        set_batoms_attr(name, value)
+        func(name, value)
 
     return setter
 
@@ -189,7 +189,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         description="Structural models",
         items=model_style_items,
         get=get_enum_attr("model_style", get_active_collection),
-        set=set_enum_attr("model_style"),
+        set=set_enum_attr("model_style", set_batoms_attr),
         default=0,
     )
 
@@ -208,7 +208,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("VDW", "van der Waals", "", 1),
                ("Ionic", "ionic", "", 2)),
         get=get_enum_attr("radius_style", get_active_collection),
-        set=set_enum_attr("radius_style"),
+        set=set_enum_attr("radius_style", set_batoms_attr),
         default=0,
     )
 
@@ -219,7 +219,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("VESTA", "VESTA", "", 1),
                ("CPK", "CPK", "", 2)),
         get=get_enum_attr("color_style", get_active_collection),
-        set=set_enum_attr("color_style"),
+        set=set_enum_attr("color_style", set_batoms_attr),
         default=0,
     )
 
@@ -231,7 +231,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("2", "central atoms, polyhedra", "", 2),
                ("3", "polyhedra", "", 3)),
         get=get_enum_attr("polyhedra_style", get_active_collection),
-        set=set_enum_attr("polyhedra_style"),
+        set=set_enum_attr("polyhedra_style", set_batoms_attr),
         default=0,
     )
 

--- a/batoms/gui/gui_batoms.py
+++ b/batoms/gui/gui_batoms.py
@@ -10,7 +10,8 @@ from bpy.props import (
     StringProperty,
 )
 from batoms import Batoms
-
+from batoms.gui.utils import (get_active_bpy_data, 
+        get_attr, get_enum_attr, set_attr, set_enum_attr)
 
 model_style_items = [("Space-filling", "Space-filling", "", 0),
                      ("Ball-and-stick", "Ball-and-Stick", "", 1),
@@ -62,21 +63,7 @@ class Batoms_PT_prepare(Panel):
         # layout.operator("batoms.replace")
 
 
-def get_active_collection():
-    """Get the collection of the active Batoms
 
-    When get the attribute of Batoms object, 
-    if the attribute if saved in the Batoms.coll.batoms,
-    we only need to read data form the colleciton, 
-    it is faster than get data from the Batoms itself.
-
-    Returns:
-        bpy.type.collection: _description_
-    """
-    context = bpy.context
-    if context.object and context.object.batoms.type != 'OTHER':
-        return bpy.data.collections[context.object.batoms.label].batoms
-    return None
 
 
 # ---------------------------------------------------
@@ -110,73 +97,8 @@ def modify_batoms_attr(context, key, value):
         bpy.context.view_layer.objects.active = batoms.obj
 
 
-def get_enum_attr(name, func):
-    """Helper function to easily get enum property.
-
-    Args:
-        name (str): name of the attribute
-    """
-
-    def getter(self):
-        batoms = func()
-        if batoms is not None:
-            return int(getattr(batoms, name))
-        else:
-            return 0
-
-    return getter
-
-
-def set_enum_attr(name, func):
-    """Helper function to easily set enum property.
-
-    Args:
-        name (str): name of the attribute
-    """
-
-    def setter(self, value):
-        items = self.bl_rna.properties[name].enum_items
-        item = items[value]
-        identifier = item.identifier
-        self[name] = identifier
-        func(name, value)
-
-    return setter
-
-
-def get_attr(name, func):
-    """Helper function to easily get property.
-
-    Args:
-        name (str): name of the attribute
-    """
-
-    def getter(self):
-        batoms = func()
-        if batoms is not None:
-            return getattr(batoms, name)
-        else:
-            prop = self.bl_rna.properties[name]
-            return prop.default
-    return getter
-
-
-def set_attr(name, func):
-    """Helper function to easily set property.
-
-    Args:
-        name (str): name of the attribute
-    """
-
-    def setter(self, value):
-        self[name] = value
-        func(name, value)
-
-    return setter
-
-
 def get_wrap(self):
-    batoms = get_active_collection()
+    batoms = get_active_bpy_data('batoms')()
     if batoms is not None:
         return batoms.wrap[0]
     else:
@@ -188,7 +110,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         name="model_style",
         description="Structural models",
         items=model_style_items,
-        get=get_enum_attr("model_style", get_active_collection),
+        get=get_enum_attr("model_style", get_active_bpy_data('batoms')),
         set=set_enum_attr("model_style", set_batoms_attr),
         default=0,
     )
@@ -196,7 +118,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
     show_label: StringProperty(
         name="label",
         description="Show label: None, Index, Species or Charge and so on",
-        get=get_attr("show_label", get_active_collection),
+        get=get_attr("show_label", get_active_bpy_data('batoms')),
         set=set_attr("show_label", set_batoms_attr),
         default="",
     )
@@ -207,7 +129,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("Covalent", "covalent", "", 0),
                ("VDW", "van der Waals", "", 1),
                ("Ionic", "ionic", "", 2)),
-        get=get_enum_attr("radius_style", get_active_collection),
+        get=get_enum_attr("radius_style", get_active_bpy_data('batoms')),
         set=set_enum_attr("radius_style", set_batoms_attr),
         default=0,
     )
@@ -218,7 +140,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
         items=(("JMOL", "JMOL", "", 0),
                ("VESTA", "VESTA", "", 1),
                ("CPK", "CPK", "", 2)),
-        get=get_enum_attr("color_style", get_active_collection),
+        get=get_enum_attr("color_style", get_active_bpy_data('batoms')),
         set=set_enum_attr("color_style", set_batoms_attr),
         default=0,
     )
@@ -230,7 +152,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
                ("1", "atoms, polyhedra", "", 1),
                ("2", "central atoms, polyhedra", "", 2),
                ("3", "polyhedra", "", 3)),
-        get=get_enum_attr("polyhedra_style", get_active_collection),
+        get=get_enum_attr("polyhedra_style", get_active_bpy_data('batoms')),
         set=set_enum_attr("polyhedra_style", set_batoms_attr),
         default=0,
     )
@@ -238,7 +160,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
     show: BoolProperty(name="show",
                        default=False,
                        description="show all object for view and rendering",
-                       get=get_attr("show", get_active_collection),
+                       get=get_attr("show", get_active_bpy_data('batoms')),
                        set=set_attr("show", set_batoms_attr)
                        )
 
@@ -252,7 +174,7 @@ class BatomsProperties(bpy.types.PropertyGroup):
     crystal_view: BoolProperty(name="crystal_view",
                        default=False,
                        description="crystal_view all object for view and rendering",
-                       get=get_attr("crystal_view", get_active_collection),
+                       get=get_attr("crystal_view", get_active_bpy_data('batoms')),
                        set=set_attr("crystal_view", set_batoms_attr)
                        )
 
@@ -260,6 +182,6 @@ class BatomsProperties(bpy.types.PropertyGroup):
         name="scale", default=1.0,
         min=0.0, soft_max=2.0,
         description="scale",
-        get=get_attr("scale", get_active_collection),
+        get=get_attr("scale", get_active_bpy_data('batoms')),
         set=set_attr("scale", set_batoms_attr)
     )

--- a/batoms/gui/gui_cell.py
+++ b/batoms/gui/gui_cell.py
@@ -8,7 +8,7 @@ from bpy.props import (BoolProperty,
 
 from batoms import Batoms
 from batoms.cell import Bcell
-from batoms.gui.gui_batoms import get_active_batoms
+from batoms.gui.utils import get_active_module
 
 class Cell_PT_prepare(Panel):
     bl_label = "Cell"
@@ -57,7 +57,7 @@ def get_cell(i1, i2):
     """Helper function to easily get cell-property."""
 
     def getter(self):
-        cell = get_active_cell()
+        cell = get_active_module('cell')()
         if cell is not None:
             return cell.array[i1, i2]
         else:
@@ -68,7 +68,7 @@ def set_cell(i1, i2):
     """Helper function to easily set cell-property."""
 
     def setter(self, value):
-        cell = get_active_cell()
+        cell = get_active_module('cell')()
         if cell is not None:
             cell[i1, i2] = value
             
@@ -179,9 +179,3 @@ def modify_transform(name, transform):
     batoms.transform(transform)
     batoms.hide = True
 
-def get_active_cell():
-    context = bpy.context
-    if context.object and context.object.batoms.type != 'OTHER':
-        cell = Bcell(label=context.object.batoms.label)
-        return cell
-    return None

--- a/batoms/gui/gui_render.py
+++ b/batoms/gui/gui_render.py
@@ -8,7 +8,7 @@ from bpy.props import (
 )
 from batoms.render.render import Render
 from batoms import Batoms
-from batoms.gui.gui_batoms import get_attr, set_attr
+from batoms.gui.utils import get_attr, set_attr
 
 
 class Render_PT_prepare(Panel):

--- a/batoms/gui/gui_slicebatoms.py
+++ b/batoms/gui/gui_slicebatoms.py
@@ -6,7 +6,6 @@ from bpy.props import (FloatProperty,
                        BoolProperty,
                        EnumProperty,
                        )
-from batoms.gui.gui_batoms import get_active_batoms
 from batoms.utils.butils import get_selected_vertices
 from batoms.slicebatoms import SliceBatoms
 from batoms.batoms import Batoms

--- a/batoms/gui/gui_slicebonds.py
+++ b/batoms/gui/gui_slicebonds.py
@@ -10,7 +10,7 @@ from batoms.utils.butils import get_selected_vertices
 from batoms.batoms import Batoms
 from batoms.bond import Bond
 from batoms.bond.slicebonds import SliceBonds
-from batoms.gui.gui_batoms import get_attr, set_attr, get_enum_attr
+from batoms.gui.utils import get_attr, set_attr, get_enum_attr
 
 # The panel.
 class Bond_PT_prepare(Panel):

--- a/batoms/gui/utils.py
+++ b/batoms/gui/utils.py
@@ -1,0 +1,133 @@
+import bpy
+from batoms.batoms import Batoms
+
+
+def get_active_bpy_data(btype = 'cell'):
+    """Helper function.
+
+    Args:
+        btype (str, optional): _description_. Defaults to 'cell'.
+    """
+    def getter():
+        """Get the collection of the active Batoms
+
+        When get the attribute of Batoms object, 
+        if the attribute if saved in the Batoms.coll.batoms,
+        we only need to read data form the colleciton, 
+        it is faster than get data from the Batoms itself.
+
+        Returns:
+            bpy.type.collection: _description_
+        """
+        context = bpy.context
+        if context.object and context.object.batoms.type != 'OTHER':
+            return getattr(bpy.data.collections[context.object.batoms.label], btype)
+        return None
+    return getter
+
+
+def get_active_module(module_name = 'cell'):
+    """Helper function.
+
+    Args:
+        module_name (str, optional): _description_. Defaults to 'cell'.
+    
+    Returns:
+        function: function to get the module
+    """
+    def getter():
+        """Get the module of Batoms by name
+
+        Returns:
+            _type_: _description_
+        """
+        context = bpy.context
+        if context.object and context.object.batoms.type != 'OTHER':
+            mode = context.object.mode
+            batoms = Batoms(label=context.object.batoms.label)
+            bpy.context.view_layer.objects.active = batoms.obj
+            bpy.ops.object.mode_set(mode=mode)
+            return getattr(batoms, module_name)
+        return None
+    return getter
+
+def set_module_attr(module_name):
+    """Helper function.
+
+    Args:
+        module_name (_type_): _description_
+    """
+    def setter(key, value):
+        module = get_active_module(module_name)()
+        if module is not None:
+            setattr(module, key, value)
+            # bpy.context.view_layer.objects.active = module.obj
+    return setter
+
+
+
+def get_enum_attr(name, func):
+    """Helper function to easily get enum property.
+
+    Args:
+        name (str): name of the attribute
+    """
+
+    def getter(self):
+        batoms = func()
+        if batoms is not None:
+            return int(getattr(batoms, name))
+        else:
+            return 0
+
+    return getter
+
+
+def set_enum_attr(name, func):
+    """Helper function to easily set enum property.
+
+    Args:
+        name (str): name of the attribute
+    """
+
+    def setter(self, value):
+        items = self.bl_rna.properties[name].enum_items
+        item = items[value]
+        identifier = item.identifier
+        self[name] = identifier
+        func(name, value)
+
+    return setter
+
+
+def get_attr(name, func):
+    """Helper function to easily get property.
+
+    Args:
+        name (str): name of the attribute
+    """
+
+    def getter(self):
+        batoms = func()
+        if batoms is not None:
+            return getattr(batoms, name)
+        else:
+            prop = self.bl_rna.properties[name]
+            return prop.default
+    return getter
+
+
+def set_attr(name, func):
+    """Helper function to easily set property.
+
+    Args:
+        name (str): name of the attribute
+    """
+
+    def setter(self, value):
+        # set value
+        self[name] = value
+        # set property of the module
+        func(name, value)
+
+    return setter

--- a/batoms/internal_data/__init__.py
+++ b/batoms/internal_data/__init__.py
@@ -45,11 +45,11 @@ def register_class():
     for cls in classes:
         register_class(cls)
     
-    enable_module()
     Collection.batoms = PointerProperty(name='Batoms',
                                         type=bpy_data.BatomsCollection)
     Object.batoms = PointerProperty(name='Batoms',
                                     type=bpy_data.BatomsObject)
+    enable_module()
     
 
 def unregister_class():
@@ -57,6 +57,7 @@ def unregister_class():
     for cls in reversed(classes):
         unregister_class(cls)
     disable_module()
+    
     del Collection.batoms
     del Object.batoms
     

--- a/batoms/plugins/__init__.py
+++ b/batoms/plugins/__init__.py
@@ -29,6 +29,7 @@ plugin_info = {
     'isosurface': ['isosurface', 'Isosurface', 'Bisosurface'],
     'molecular_surface': ['molecular_surface', 'MolecularSurface', 'Bmolecularsurface'],
     'magres': ['magres', 'Magres', 'Bmagres'],
+    'template': ['template', 'Template', 'Btemplate'],
     }
 
 def enable_plugin():

--- a/batoms/plugins/base.py
+++ b/batoms/plugins/base.py
@@ -47,7 +47,8 @@ class PluginObject(BaseObject):
         self.batoms = batoms
         self.label = label
         self.name = name
-        BaseObject.__init__(self, label, name)
+        obj_name = '%s_%s' % (label, name)
+        BaseObject.__init__(self, obj_name)
         self.settings = PluginSettings(
             self.label, parent=self)
     

--- a/batoms/plugins/base.py
+++ b/batoms/plugins/base.py
@@ -1,0 +1,138 @@
+"""Definition of the parent plugin class.
+
+"""
+
+import bpy
+from time import time
+import numpy as np
+from batoms.base.collection import Setting
+from batoms.base.object import BaseObject
+import logging
+logger = logging.getLogger(__name__)
+
+
+class PluginSettings(Setting):
+    def __init__(self, label, parent) -> None:
+        """Plugin Settings
+        This object store the plugin setting.
+
+        Parameters:
+
+        label: str
+            The label define the batoms object that
+            a Setting belong to.
+        parent: Plugin Class
+
+        """
+        Setting.__init__(self, label, coll_name=label)
+        self.label = label
+        self.parent = parent
+        self.name = 'B{}'.format(parent.name)
+
+    
+
+class PluginObject(BaseObject):
+    def __init__(self,
+                 label,
+                 name='plugin',
+                 batoms=None,
+                 ):
+        """Plugin Class
+
+        Args:
+            label (string): _description_.
+            batoms (Batoms, optional): _description_. Defaults to None.
+        """
+        #
+        self.batoms = batoms
+        self.label = label
+        self.name = name
+        BaseObject.__init__(self, label, name)
+        self.settings = PluginSettings(
+            self.label, parent=self)
+    
+    def build_materials(self, name, color,
+                        node_inputs=None,
+                        material_style='default',
+                        backface_culling = False,
+                        vertex_color = None,
+                        ):
+        """Create materials
+
+        Args:
+            name (string): _description_
+            color (array, (1x4)): _description_
+            node_inputs (dict, optional): _description_. Defaults to None.
+            material_style (string, optional): _description_. Defaults to 'default'.
+
+        Returns:
+            bpy.type.material: _description_
+        """
+        from batoms.material import create_material
+        if name in bpy.data.materials:
+            mat = bpy.data.materials.get(name)
+            bpy.data.materials.remove(mat, do_unlink=True)
+        mat = create_material(name,
+                              color=color,
+                              node_inputs=node_inputs,
+                              material_style=material_style,
+                              backface_culling=backface_culling,
+                              vertex_color=vertex_color)
+        return mat
+
+    def draw(self):
+        from batoms.utils.butils import clean_coll_object_by_type
+        # delete old object
+        clean_coll_object_by_type(self.batoms.coll, 'PLUGIN')
+        for setting in self.settings.bpy_setting:
+            self.draw_item(setting)
+
+    
+    def draw_item(self, setting):
+        """
+        """
+        tstart = time()
+        indices = self.batoms.selects[setting.select].indices
+        if len(indices) == 0:
+            return
+        # select atoms
+        positions = self.batoms.positions[indices]
+        logger.debug('Draw Template: %s' % (time() - tstart))
+
+    @property
+    def objs(self):
+        objs = {}
+        for setting in self.settings.bpy_setting:
+            ms_name = '{}_{}_{}'.format(self.label, self.name, setting.name)
+            obj = bpy.data.objects.get(ms_name)
+            objs[setting.name] = obj
+        return objs
+
+    @property
+    def mat(self):
+        return bpy.data.materials.get(self.name)
+   
+    def as_dict(self):
+        """
+        """
+        data = {}
+        data['settings'] = self.settings.as_dict()
+        data.update(self.settings.bpy_data.as_dict())
+        return data
+    
+    @property
+    def show(self):
+        return self.get_show()
+
+    @show.setter
+    def show(self, state):
+        self.set_show(state)
+
+    def get_show(self):
+        return self.settings.bpy_data.show
+
+    def set_show(self, state):
+        self.settings.bpy_data.show = state
+        for name, obj in self.objs.items():
+            obj.hide_render = not state
+            obj.hide_set(not state)

--- a/batoms/plugins/base.py
+++ b/batoms/plugins/base.py
@@ -104,9 +104,9 @@ class PluginObject(BaseObject):
     def objs(self):
         objs = {}
         for setting in self.settings.bpy_setting:
-            ms_name = '{}_{}_{}'.format(self.label, self.name, setting.name)
-            obj = bpy.data.objects.get(ms_name)
-            objs[setting.name] = obj
+            name = '{}_{}_{}'.format(self.label, self.name, setting.name)
+            obj = bpy.data.objects.get(name)
+            objs[name] = obj
         return objs
 
     @property

--- a/batoms/plugins/cavity/__init__.py
+++ b/batoms/plugins/cavity/__init__.py
@@ -3,41 +3,52 @@ from .cavity import Cavity
 from . import (
     bpy_data,
     ops,
-    ui_list,
+    gui,
 )
 
 
-classes = [
+classes_bpy_data = [
     # internal data first
     bpy_data.CavitySetting,
     bpy_data.Cavity,
+    gui.CavityProperties,
+]
+    
+classes = [
     ops.CavityAdd,
     ops.CavityRemove,
     ops.CavityDraw,
-    ui_list.BATOMS_MT_cavity_context_menu,
-    ui_list.BATOMS_UL_cavity,
-    ui_list.BATOMS_PT_cavity,
+    gui.VIEW3D_PT_Batoms_cavity,
+    gui.BATOMS_MT_cavity_context_menu,
+    gui.BATOMS_UL_cavity,
+    gui.BATOMS_PT_cavity,
 ]
 
 
 def register_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.props import PointerProperty
     from bpy.utils import register_class
-    for cls in classes:
+    for cls in classes_bpy_data:
         register_class(cls)
     # attach to blender internal data
     Collection.Bcavity = PointerProperty(name='Bcavity',
                                         type=bpy_data.Cavity)
     Object.Bcavity = PointerProperty(name='Bcavity',
                                     type=bpy_data.Cavity)
-
+    Scene.Bcavity = PointerProperty(type=gui.CavityProperties)
+#
+    for cls in classes:
+        register_class(cls)
 
 def unregister_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
 
     del Collection.Bcavity
     del Object.Bcavity
+    del Scene.Bcavity
+    for cls in reversed(classes):
+        unregister_class(cls)
+    for cls in reversed(classes_bpy_data):
+        unregister_class(cls)

--- a/batoms/plugins/cavity/bpy_data.py
+++ b/batoms/plugins/cavity/bpy_data.py
@@ -3,6 +3,7 @@ from bpy.props import (StringProperty,
                        BoolProperty,
                        IntProperty,
                        FloatProperty,
+                       EnumProperty,
                        FloatVectorProperty,
                        CollectionProperty,
                        )
@@ -55,6 +56,14 @@ class Cavity(bpy.types.PropertyGroup):
     """
 
     active: BoolProperty(name="active", default=False)
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=(('0', "Surface", "Surface"),
+               ('1', "Dot", "Dot surface"),
+               ('2', "Wireframe", "Use wireframe")),
+        default='0')
+    show: BoolProperty(name="show", default=True)
     atomRadius: FloatProperty(name="atomRadius", default=0.5)
     minCave: FloatProperty(name="minCave", default=3)
     resolution: FloatProperty(name="resolution", default=1)

--- a/batoms/plugins/cavity/cavity.py
+++ b/batoms/plugins/cavity/cavity.py
@@ -9,6 +9,7 @@ from time import time
 import numpy as np
 from batoms.attribute import Attributes
 from batoms.base.object import ObjectGN
+from batoms.plugins.base import PluginObject
 from .setting import CavitySettings
 from scipy import spatial
 from batoms.utils.butils import object_mode, get_nodes_by_name
@@ -38,7 +39,7 @@ default_cavity_datas = {
 }
 
 
-class Cavity(ObjectGN):
+class Cavity(ObjectGN, PluginObject):
     def __init__(self,
                  label=None,
                  cavity_datas=None,
@@ -59,6 +60,7 @@ class Cavity(ObjectGN):
         self.label = label
         name = 'cavity'
         ObjectGN.__init__(self, label, name)
+        PluginObject.__init__(self, label, 'cavity', batoms)
         if resolution is not None:
             self.resolution = resolution
         if minCave is not None:
@@ -470,6 +472,14 @@ class Cavity(ObjectGN):
         name = '%s_cavity' % (self.label)
         obj = self.obj
         self.set_obj_frames(name, obj, frames['centers'])
+
+    @property
+    def objs(self):
+        objs = {}
+        name = '{}_{}'.format(self.label, self.name)
+        obj = bpy.data.objects.get(name)
+        objs[name] = obj
+        return objs
 
     @property
     def setting(self):

--- a/batoms/plugins/cavity/gui.py
+++ b/batoms/plugins/cavity/gui.py
@@ -3,6 +3,98 @@
 
 import bpy
 from bpy.types import Menu, Panel, UIList
+from bpy.props import (
+    BoolProperty,
+    FloatProperty,
+    EnumProperty,
+    StringProperty,
+)
+
+
+
+from batoms import Batoms
+from batoms.gui.utils import (get_active_bpy_data, 
+        get_attr, get_enum_attr, set_attr, set_enum_attr,
+        get_active_module, set_module_attr
+        )
+
+
+model_style_items = [("Surface", "Surface", "", 0),
+                     ("Dot", "Dot", "", 1),
+                     ("Wireframe", "Wireframe", "", 2),
+                     ]
+
+
+
+class CavityProperties(bpy.types.PropertyGroup):
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=model_style_items,
+        get=get_enum_attr("model_style", get_active_bpy_data('Bcavity')),
+        set=set_enum_attr("model_style", set_module_attr('cavity')),
+        default=0,
+    )
+
+    show: BoolProperty(name="show",
+                       default=False,
+                       description="show all object for view and rendering",
+                       get=get_attr("show", get_active_bpy_data('Bcavity')),
+                       set=set_attr("show", set_module_attr('cavity'))
+                       )
+    atomRadius: FloatProperty(name="atomRadius", 
+                default=0.5,
+                description="average radius of the atoms",
+                get=get_attr("atomRadius", get_active_bpy_data('Bcavity')),
+                set=set_attr("atomRadius", set_module_attr('cavity'))
+                )
+    minCave: FloatProperty(name="minCave", 
+                default=3,
+                description="minmum radius of the cave",
+                get=get_attr("minCave", get_active_bpy_data('Bcavity')),
+                set=set_attr("minCave", set_module_attr('cavity'))
+                )
+    resolution: FloatProperty(name="resolution", 
+                default=1,
+                description="resolution",
+                get=get_attr("resolution", get_active_bpy_data('Bcavity')),
+                set=set_attr("resolution", set_module_attr('cavity'))
+                )
+
+
+
+class VIEW3D_PT_Batoms_cavity(Panel):
+    bl_label = "Cavity"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Surface"
+    bl_idname = "VIEW3D_PT_Batoms_cavity"
+    # bl_options = {'DEFAULT_CLOSED'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.object
+        if obj:
+            return obj.batoms.type != 'OTHER'
+        else:
+            return False
+
+    def draw(self, context):
+        name = 'None'
+        if context.object:
+            if context.object.batoms.type != 'OTHER':
+                name = context.object.batoms.label
+        layout = self.layout
+        # layout.label(text="Active: " + name)
+        iso = context.scene.Bcavity
+
+        layout.label(text="Model style")
+        layout.prop(iso, "model_style", expand=True)
+        layout.prop(iso, "show", expand=True)
+        layout.prop(iso, "minCave")
+        layout.prop(iso, "resolution")
+        layout.prop(iso, "atomRadius")
+        layout.separator()
 
 
 class BATOMS_MT_cavity_context_menu(Menu):
@@ -37,11 +129,12 @@ class BATOMS_UL_cavity(UIList):
 
 
 class BATOMS_PT_cavity(Panel):
-    bl_label = "Cavity"
+    bl_label = "Item settings"
     bl_category = "Surface"
     bl_idname = "BATOMS_PT_cavity"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_parent_id = 'VIEW3D_PT_Batoms_cavity'
     # bl_options = {'DEFAULT_CLOSED'}
 
     COMPAT_ENGINES = {'BLENDER_RENDER', 'BLENDER_EEVEE', 'BLENDER_WORKBENCH'}

--- a/batoms/plugins/cavity/gui.py
+++ b/batoms/plugins/cavity/gui.py
@@ -69,7 +69,7 @@ class VIEW3D_PT_Batoms_cavity(Panel):
     bl_region_type = "UI"
     bl_category = "Surface"
     bl_idname = "VIEW3D_PT_Batoms_cavity"
-    # bl_options = {'DEFAULT_CLOSED'}
+    bl_options = {'DEFAULT_CLOSED'}
 
     @classmethod
     def poll(cls, context):

--- a/batoms/plugins/crystal_shape/__init__.py
+++ b/batoms/plugins/crystal_shape/__init__.py
@@ -3,42 +3,53 @@ from .crystal_shape import CrystalShape
 from . import (
     bpy_data,
     ops,
-    ui_list,
+    gui,
 )
 
 
-classes = [
+classes_bpy_data = [
     # internal data first
     bpy_data.CrystalShapeSetting,
     bpy_data.CrystalShape,
+    gui.CrystalShapeProperties,
+]
+classes = [
     ops.CrystalShapeAdd,
     ops.CrystalShapeRemove,
     ops.CrystalShapeDraw,
     ops.CrystalShapeModify,
-    ui_list.BATOMS_MT_crystal_shape_context_menu,
-    ui_list.BATOMS_UL_crystal_shape,
-    ui_list.BATOMS_PT_crystal_shape,
+    gui.VIEW3D_PT_Batoms_crystal_shape,
+    gui.BATOMS_MT_crystal_shape_context_menu,
+    gui.BATOMS_UL_crystal_shape,
+    gui.BATOMS_PT_crystal_shape,
 ]
 
 
 def register_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.props import PointerProperty
     from bpy.utils import register_class
-    for cls in classes:
+    #
+    for cls in classes_bpy_data:
         register_class(cls)
     # attach to blender internal data
     Collection.Bcrystalshape = PointerProperty(name='Bcrystalshape',
                                         type=bpy_data.CrystalShape)
     Object.Bcrystalshape = PointerProperty(name='Bcrystalshape',
                                     type=bpy_data.CrystalShape)
-
+    Scene.Bcrystalshape = PointerProperty(type=gui.CrystalShapeProperties)
+    #
+    for cls in classes:
+        register_class(cls)
 
 def unregister_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
 
     del Collection.Bcrystalshape
     del Object.Bcrystalshape
+    del Scene.Bcrystalshape
+    for cls in reversed(classes):
+        unregister_class(cls)
+    for cls in reversed(classes_bpy_data):
+        unregister_class(cls)

--- a/batoms/plugins/crystal_shape/bpy_data.py
+++ b/batoms/plugins/crystal_shape/bpy_data.py
@@ -5,6 +5,7 @@ from bpy.props import (
                        BoolProperty,
                        IntProperty,
                        FloatProperty,
+                       EnumProperty,
                        FloatVectorProperty,
                        CollectionProperty,
                        )
@@ -74,6 +75,14 @@ class CrystalShape(bpy.types.PropertyGroup):
 
     """
     active: BoolProperty(name="active", default=False)
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=(('0', "Surface", "Surface"),
+               ('1', "Dot", "Dot surface"),
+               ('2', "Wireframe", "Use wireframe")),
+        default='0')
+    show: BoolProperty(name="show", default=True)
     settings: CollectionProperty(name='CrystalShapeSetting',
                                 type=CrystalShapeSetting)
 

--- a/batoms/plugins/crystal_shape/crystal_shape.py
+++ b/batoms/plugins/crystal_shape/crystal_shape.py
@@ -5,14 +5,14 @@
 import bpy
 from time import time
 import numpy as np
-from batoms.base.object import BaseObject
+from batoms.plugins.base import PluginObject
 from .setting import CrystalShapeSettings
 from batoms.draw import draw_cylinder, draw_surface_from_vertices
 import logging
 # logger = logging.getLogger('batoms')
 logger = logging.getLogger(__name__)
 
-class CrystalShape(BaseObject):
+class CrystalShape(PluginObject):
     def __init__(self,
                  label=None,
                  location=np.array([0, 0, 0]),
@@ -28,8 +28,7 @@ class CrystalShape(BaseObject):
         #
         self.batoms = batoms
         self.label = label
-        name = 'plane'
-        BaseObject.__init__(self, label, name)
+        PluginObject.__init__(self, label, 'crystalshape', batoms)
         self.settings = CrystalShapeSettings(
             self.label,  parent=self)
         self.settings.bpy_data.active = True
@@ -148,7 +147,7 @@ class CrystalShape(BaseObject):
         for species, plane in planes.items():
             if plane_name.upper() != "ALL" and species != plane_name:
                 continue
-            name = '%s_%s_%s' % (self.label, 'crystal', species)
+            name = '%s_%s_%s' % (self.label, self.name, species)
             self.delete_obj(name)
             obj = draw_surface_from_vertices(name, plane,
                                              coll=self.batoms.coll,

--- a/batoms/plugins/crystal_shape/gui.py
+++ b/batoms/plugins/crystal_shape/gui.py
@@ -3,6 +3,77 @@
 
 import bpy
 from bpy.types import Menu, Panel, UIList
+from bpy.props import (
+    BoolProperty,
+    FloatProperty,
+    EnumProperty,
+    StringProperty,
+)
+
+
+
+from batoms import Batoms
+from batoms.gui.utils import (get_active_bpy_data, 
+        get_attr, get_enum_attr, set_attr, set_enum_attr,
+        get_active_module, set_module_attr
+        )
+
+
+model_style_items = [("Surface", "Surface", "", 0),
+                     ("Dot", "Dot", "", 1),
+                     ("Wireframe", "Wireframe", "", 2),
+                     ]
+
+
+
+class CrystalShapeProperties(bpy.types.PropertyGroup):
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=model_style_items,
+        get=get_enum_attr("model_style", get_active_bpy_data('Bcrystalshape')),
+        set=set_enum_attr("model_style", set_module_attr('crystal_shape')),
+        default=0,
+    )
+
+    show: BoolProperty(name="show",
+                       default=False,
+                       description="show all object for view and rendering",
+                       get=get_attr("show", get_active_bpy_data('Bcrystalshape')),
+                       set=set_attr("show", set_module_attr('crystal_shape'))
+                       )
+
+
+
+class VIEW3D_PT_Batoms_crystal_shape(Panel):
+    bl_label = "Crystal Shape"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "Surface"
+    bl_idname = "VIEW3D_PT_Batoms_crystal_shape"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.object
+        if obj:
+            return obj.batoms.type != 'OTHER'
+        else:
+            return False
+
+    def draw(self, context):
+        name = 'None'
+        if context.object:
+            if context.object.batoms.type != 'OTHER':
+                name = context.object.batoms.label
+        layout = self.layout
+        # layout.label(text="Active: " + name)
+        iso = context.scene.Bcrystalshape
+
+        layout.label(text="Model style")
+        layout.prop(iso, "model_style", expand=True)
+        layout.prop(iso, "show", expand=True)
+        layout.separator()
 
 
 class BATOMS_MT_crystal_shape_context_menu(Menu):
@@ -41,6 +112,7 @@ class BATOMS_PT_crystal_shape(Panel):
     bl_idname = "BATOMS_PT_crystal_shape"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
+    bl_parent_id = 'VIEW3D_PT_Batoms_crystal_shape'
     # bl_options = {'DEFAULT_CLOSED'}
 
     COMPAT_ENGINES = {'BLENDER_RENDER', 'BLENDER_EEVEE', 'BLENDER_WORKBENCH'}

--- a/batoms/plugins/lattice_plane/__init__.py
+++ b/batoms/plugins/lattice_plane/__init__.py
@@ -1,44 +1,57 @@
+from . import gui
 from .lattice_plane import LatticePlane
 
 from . import (
     bpy_data,
     ops,
-    ui_list,
+    gui,
 )
 
 
-classes = [
+classes_bpy_data = [
     # internal data first
     bpy_data.LatticePlaneSetting,
     bpy_data.LatticePlane,
+    gui.LatticePlaneProperties,
+]
+classes = [
     ops.LatticePlaneAdd,
     ops.LatticePlaneRemove,
     ops.LatticePlaneDraw,
     ops.LatticePlaneModify,
-    ui_list.BATOMS_MT_lattice_plane_context_menu,
-    ui_list.BATOMS_UL_lattice_plane,
-    ui_list.BATOMS_PT_lattice_plane,
+    gui.VIEW3D_PT_Batoms_lattice_plane,
+    gui.BATOMS_MT_lattice_plane_context_menu,
+    gui.BATOMS_UL_lattice_plane,
+    gui.BATOMS_PT_lattice_plane,
 ]
 
 
 def register_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.props import PointerProperty
     from bpy.utils import register_class
-    for cls in classes:
+    #
+    for cls in classes_bpy_data:
         register_class(cls)
     # attach to blender internal data
     Collection.Blatticeplane = PointerProperty(name='Blatticeplane',
                                         type=bpy_data.LatticePlane)
     Object.Blatticeplane = PointerProperty(name='Blatticeplane',
                                     type=bpy_data.LatticePlane)
-
+    Scene.Blatticeplane = PointerProperty(type=gui.LatticePlaneProperties)
+    #
+    for cls in classes:
+        register_class(cls)
 
 def unregister_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
+    
 
     del Collection.Blatticeplane
     del Object.Blatticeplane
+    del Scene.Blatticeplane
+    for cls in reversed(classes):
+        unregister_class(cls)
+    for cls in reversed(classes_bpy_data):
+        unregister_class(cls)

--- a/batoms/plugins/lattice_plane/bpy_data.py
+++ b/batoms/plugins/lattice_plane/bpy_data.py
@@ -5,6 +5,7 @@ from bpy.props import (
                        BoolProperty,
                        IntProperty,
                        FloatProperty,
+                       EnumProperty,
                        FloatVectorProperty,
                        CollectionProperty,
                        )
@@ -33,7 +34,7 @@ class LatticePlaneSetting(Base):
     slicing: BoolProperty(name="slicing", default=False)
     boundary: BoolProperty(name="boundary", default=False)
     scale: FloatProperty(name="scale", default=1)
-    show_edge: BoolProperty(name="show_edge", default=True)
+    show_edge: BoolProperty(name="show_edge", default=False)
     width: FloatProperty(name="width", default=0.01)
 
     @property
@@ -74,6 +75,14 @@ class LatticePlane(bpy.types.PropertyGroup):
 
     """
     active: BoolProperty(name="active", default=False)
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=(('0', "Surface", "Surface"),
+               ('1', "Dot", "Dot surface"),
+               ('2', "Wireframe", "Use wireframe")),
+        default='0')
+    show: BoolProperty(name="show", default=True)
     settings: CollectionProperty(name='LatticePlaneSetting',
                                 type=LatticePlaneSetting)
 

--- a/batoms/plugins/lattice_plane/gui.py
+++ b/batoms/plugins/lattice_plane/gui.py
@@ -46,12 +46,12 @@ class LatticePlaneProperties(bpy.types.PropertyGroup):
 
 
 class VIEW3D_PT_Batoms_lattice_plane(Panel):
-    bl_label = "lattice_plane"
+    bl_label = "Lattice Plane"
     bl_space_type = "VIEW_3D"
     bl_region_type = "UI"
     bl_category = "Surface"
     bl_idname = "VIEW3D_PT_Batoms_lattice_plane"
-    # bl_options = {'DEFAULT_CLOSED'}
+    bl_options = {'DEFAULT_CLOSED'}
 
     @classmethod
     def poll(cls, context):

--- a/batoms/plugins/lattice_plane/lattice_plane.py
+++ b/batoms/plugins/lattice_plane/lattice_plane.py
@@ -8,7 +8,7 @@ import bpy
 import bmesh
 from time import time
 import numpy as np
-from batoms.base.object import BaseObject
+from batoms.plugins.base import PluginObject
 from .setting import LatticePlaneSettings
 from batoms.draw import draw_cylinder, draw_surface_from_vertices
 import logging
@@ -16,7 +16,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class LatticePlane(BaseObject):
+class LatticePlane(PluginObject):
     def __init__(self,
                  label=None,
                  location=np.array([0, 0, 0]),
@@ -32,8 +32,7 @@ class LatticePlane(BaseObject):
         #
         self.batoms = batoms
         self.label = label
-        name = 'plane'
-        BaseObject.__init__(self, label, name)
+        PluginObject.__init__(self, label, 'latticeplane', batoms)
         self.settings = LatticePlaneSettings(
             self.label, parent=self)
         self.settings.bpy_data.active = True
@@ -300,12 +299,12 @@ class LatticePlane(BaseObject):
             if plane_name.upper() != "ALL" and species != plane_name:
                 continue
             if plane['boundary']:
-                name = '%s_%s_%s' % (self.label, 'plane', species)
+                name = '%s_%s_%s' % (self.label, self.name, species)
                 self.delete_obj(name)
                 self.build_boundary(plane['indices'])
                 bpy.context.view_layer.update()
             else:
-                name = '%s_%s_%s' % (self.label, 'plane', species)
+                name = '%s_%s_%s' % (self.label, self.name, species)
                 self.delete_obj(name)
                 obj = draw_surface_from_vertices(name, plane,
                                                  coll=self.batoms.coll,

--- a/batoms/plugins/template/__init__.py
+++ b/batoms/plugins/template/__init__.py
@@ -3,40 +3,50 @@ from .template import Template
 from . import (
     bpy_data,
     ops,
-    ui_list,
+    gui,
 )
 
 
-classes = [
+classes_bpy_data = [
     bpy_data.TemplateSetting,
     bpy_data.Template,
+    gui.TemplateProperties,
+]
+classes = [
     ops.TemplateAdd,
     ops.TemplateRemove,
     ops.TemplateDraw,
-    ui_list.BATOMS_MT_template_context_menu,
-    ui_list.BATOMS_UL_template,
-    ui_list.BATOMS_PT_template,
+    gui.VIEW3D_PT_Batoms_template,
+    gui.BATOMS_MT_template_context_menu,
+    gui.BATOMS_UL_template,
+    gui.BATOMS_PT_template,
 ]
 
 
 def register_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.props import PointerProperty
     from bpy.utils import register_class
-    for cls in classes:
+    for cls in classes_bpy_data:
         register_class(cls)
     # attach to blender internal data
     Collection.Btemplate = PointerProperty(name='Btemplate',
                                         type=bpy_data.Template)
     Object.Btemplate = PointerProperty(name='Btemplate',
                                     type=bpy_data.Template)
-
+    Scene.Btemplate = PointerProperty(type=gui.TemplateProperties)
+    #
+    for cls in classes:
+        register_class(cls)
 
 def unregister_class():
-    from bpy.types import Collection, Object
+    from bpy.types import Collection, Object, Scene
     from bpy.utils import unregister_class
-    for cls in reversed(classes):
-        unregister_class(cls)
-
+    #
     del Collection.Btemplate
     del Object.Btemplate
+    del Scene.Btemplate
+    for cls in reversed(classes):
+        unregister_class(cls)
+    for cls in reversed(classes_bpy_data):
+        unregister_class(cls)

--- a/batoms/plugins/template/bpy_data.py
+++ b/batoms/plugins/template/bpy_data.py
@@ -2,6 +2,9 @@ import bpy
 from bpy.props import (StringProperty,
                        BoolProperty,
                        IntProperty,
+                       FloatProperty,
+                       FloatVectorProperty,
+                       EnumProperty,
                        CollectionProperty,
                        )
 
@@ -15,13 +18,19 @@ class TemplateSetting(Base):
     flag: BoolProperty(name="flag", default=False)
     name: StringProperty(name="name")
     label: StringProperty(name="label", default='')
-   
+    prop1: FloatProperty(name="prop1", default=1)
+    color: FloatVectorProperty(name="color", size=4,
+                               subtype='COLOR',
+                               min=0, max=1,
+                               default=[0, 0, 1, 0.5]
+                               )
 
     def as_dict(self) -> dict:
         setdict = {
             'flag': self.flag,
             'name': self.name,
             'label': self.label,
+            'color': self.color[:],
         }
         return setdict
 
@@ -38,6 +47,13 @@ class Template(bpy.types.PropertyGroup):
 
     """
     active: BoolProperty(name="active", default=False)
+    model_style: EnumProperty(
+        name="model_style",
+        description="Structural models",
+        items=(('0', "Surface", "Surface"),
+               ('1', "Dot", "Dot surface"),
+               ('2', "Wireframe", "Use wireframe")),
+        default='0')
     show: BoolProperty(name="show", default=True)
     ui_list_index: IntProperty(name="ui_list_index",
                               default=0)

--- a/batoms/plugins/template/gui.py
+++ b/batoms/plugins/template/gui.py
@@ -81,10 +81,10 @@ class BATOMS_MT_template_context_menu(Menu):
 
     def draw(self, _context):
         layout = self.layout
-        op = layout.operator("surface.template_add", icon='ADD',
+        op = layout.operator("template.template_add", icon='ADD',
                              text="Add Molecular Surface")
         layout.separator()
-        op = layout.operator("surface.template_remove", icon='X',
+        op = layout.operator("template.template_remove", icon='X',
                              text="Delete All Molecular Surface")
         op.all = True
 
@@ -143,8 +143,8 @@ class BATOMS_PT_template(Panel):
                           ba, "ui_list_index", rows=rows)
 
         col = row.column(align=True)
-        op = col.operator("surface.template_add", icon='ADD', text="")
-        op = col.operator("surface.template_remove", icon='REMOVE', text="")
+        op = col.operator("template.template_add", icon='ADD', text="")
+        op = col.operator("template.template_remove", icon='REMOVE', text="")
         if kb is not None:
             op.name = kb.name
         col.separator()
@@ -175,4 +175,4 @@ class BATOMS_PT_template(Panel):
             col.prop(kb, "color",  text="color")
             col.separator()
             op = layout.operator(
-                "surface.template_draw", icon='GREASEPENCIL', text="Draw")
+                "template.template_draw", icon='GREASEPENCIL', text="Draw")

--- a/batoms/plugins/template/gui.py
+++ b/batoms/plugins/template/gui.py
@@ -51,7 +51,7 @@ class VIEW3D_PT_Batoms_template(Panel):
     bl_region_type = "UI"
     bl_category = "Surface"
     bl_idname = "VIEW3D_PT_Batoms_template"
-    # bl_options = {'DEFAULT_CLOSED'}
+    bl_options = {'DEFAULT_CLOSED'}
 
     @classmethod
     def poll(cls, context):

--- a/batoms/plugins/template/ops.py
+++ b/batoms/plugins/template/ops.py
@@ -7,7 +7,7 @@ from batoms.ops.base import OperatorBatoms
 
 
 class TemplateAdd(OperatorBatoms):
-    bl_idname = "surface.template_add"
+    bl_idname = "template.template_add"
     bl_label = "Add template"
     bl_description = ("Add template to a Batoms")
 
@@ -24,7 +24,7 @@ class TemplateAdd(OperatorBatoms):
 
 
 class TemplateRemove(OperatorBatoms):
-    bl_idname = "surface.template_remove"
+    bl_idname = "template.template_remove"
     bl_label = "Remove template"
     bl_description = ("Remove template to a Batoms")
 
@@ -45,7 +45,7 @@ class TemplateRemove(OperatorBatoms):
 
 
 class TemplateDraw(OperatorBatoms):
-    bl_idname = "surface.template_draw"
+    bl_idname = "template.template_draw"
     bl_label = "Draw template"
     bl_description = ("Draw template to a Batoms")
 
@@ -56,7 +56,7 @@ class TemplateDraw(OperatorBatoms):
     def execute(self, context):
         obj = context.object
         batoms = Batoms(label=obj.batoms.label)
-        batoms.template.draw(self.name)
+        batoms.template.draw()
         context.view_layer.objects.active = batoms.obj
         return {'FINISHED'}
 

--- a/batoms/plugins/template/setting.py
+++ b/batoms/plugins/template/setting.py
@@ -23,9 +23,6 @@ class TemplateSettings(Setting):
         self.label = label
         self.name = 'Btemplate'
         self.parent = parent
-        # initialize a default setting
-        if len(self) == 0:
-            self['1'] = {'select': 'all'}
 
     def add(self, name, datas={}):
         self[name] = datas
@@ -43,8 +40,8 @@ class TemplateSettings(Setting):
         s = "-"*60 + "\n"
         s = "name  type select\n"
         for setting in self.bpy_setting:
-            s += "{:4s}   {:6s}   {:6s}".format(
-                setting.name, setting.type, setting.select)
+            s += "{:4s}   {:1.2f}".format(
+                setting.name,  setting.prop1)
         s += "-"*60 + "\n"
         return s
     

--- a/batoms/plugins/template/template.py
+++ b/batoms/plugins/template/template.py
@@ -17,7 +17,6 @@ class Template(BaseObject):
     def __init__(self,
                  label,
                  batoms=None,
-                 tensors = None,
                  ):
         """Template Class
 
@@ -28,7 +27,6 @@ class Template(BaseObject):
         #
         self.batoms = batoms
         self.label = label
-        self.tensors = tensors
         name = 'plugin'
         BaseObject.__init__(self, label, name)
         self.settings = TemplateSettings(

--- a/batoms/plugins/template/template.py
+++ b/batoms/plugins/template/template.py
@@ -7,13 +7,13 @@ This module defines the plugin object in the Batoms package.
 import bpy
 from time import time
 import numpy as np
-from batoms.base.object import BaseObject
+from batoms.plugins.base import PluginObject
 from .setting import TemplateSettings
 import logging
 logger = logging.getLogger(__name__)
 
 
-class Template(BaseObject):
+class Template(PluginObject):
     def __init__(self,
                  label,
                  batoms=None,
@@ -27,8 +27,7 @@ class Template(BaseObject):
         #
         self.batoms = batoms
         self.label = label
-        name = 'plugin'
-        BaseObject.__init__(self, label, name)
+        PluginObject.__init__(self, label, 'template', batoms)
         self.settings = TemplateSettings(
             self.label, parent=self)
         self.settings.bpy_data.active = True
@@ -64,7 +63,7 @@ class Template(BaseObject):
         from batoms.utils.butils import clean_coll_object_by_type
         # delete old object
         clean_coll_object_by_type(self.batoms.coll, 'TEMPLATE')
-        for setting in self.settings.collection:
+        for setting in self.settings.bpy_setting:
             self.draw_plugin(setting)
 
     
@@ -72,17 +71,12 @@ class Template(BaseObject):
         """
         """
         tstart = time()
-        indices = self.batoms.selects[setting.select].indices
-        if len(indices) == 0:
-            return
-        # select atoms
-        positions = self.batoms.positions[indices]
         logger.debug('Draw Template: %s' % (time() - tstart))
 
     @property
     def objs(self):
         objs = {}
-        for setting in self.settings.collection:
+        for setting in self.settings.bpy_setting:
             ms_name = '%s_%s' % (self.label, setting.name)
             obj = bpy.data.objects.get(ms_name)
             objs[setting.name] = obj

--- a/batoms/render/camera.py
+++ b/batoms/render/camera.py
@@ -42,16 +42,16 @@ class Camera(BaseObject):
         self.label = label
         self.name = name
         obj_name = "%s_camera_%s" % (label, name)
-        bobj_name = "Bcamera"
-        BaseObject.__init__(self, obj_name=obj_name, bobj_name=bobj_name)
+        btype = "Bcamera"
+        BaseObject.__init__(self, obj_name=obj_name, btype=btype)
         self.create_camera(type, location,
                            lens=lens, coll=coll, look_at=look_at,
                            lock_camera_to_view=lock_camera_to_view)
         self.obj.data.lens_unit = 'FOV'
 
-    def get_bobj(self):
-        bobj = getattr(self.obj, self.bobj_name)
-        return bobj
+    def get_bpy_data(self):
+        bpy_data = getattr(self.obj, self.btype)
+        return bpy_data
 
     @property
     def lens(self):

--- a/batoms/render/light.py
+++ b/batoms/render/light.py
@@ -43,9 +43,9 @@ class Light(BaseObject):
         self.label = label
         self.name = name
         obj_name = "%s_light_%s" % (label, name)
-        bobj_name = "Blight"
+        btype = "Blight"
         self.coll_name = "%s_render" % (label)
-        BaseObject.__init__(self, obj_name=obj_name, bobj_name=bobj_name)
+        BaseObject.__init__(self, obj_name=obj_name, btype=btype)
         self.create_light(type, location, energy)
         self.direction = direction
         self.lock_to_camera = lock_to_camera
@@ -58,7 +58,7 @@ class Light(BaseObject):
         return bpy.data.collections.get(self.coll_name)
 
     def get_bobj(self):
-        bobj = getattr(self.obj, self.bobj_name)
+        bobj = getattr(self.obj, self.btype)
         return bobj
 
     @property

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -1,9 +1,11 @@
-import bpy
-import pytest
-from batoms.batoms import Batoms
-from ase.build import molecule, bulk
-from batoms.bio.bio import read
 from time import time
+
+import bpy
+import numpy as np
+import pytest
+from ase.build import bulk, molecule
+from batoms.batoms import Batoms
+from batoms.bio.bio import read
 
 try:
     from _common_helpers import has_display, set_cycles_res
@@ -66,6 +68,17 @@ def test_cavity_ops():
     print(mof.cavity.settings)
     assert len(mof.cavity.settings) == 0
 
+def test_gui():
+    """latticeplane panel"""
+    from batoms.batoms import Batoms
+    from batoms.bio.bio import read
+    bpy.ops.batoms.delete()
+    mof = read("../tests/datas/mof-5.cif")
+    assert bpy.context.scene.Bcavity.show == True
+    bpy.context.scene.Bcavity.show = False
+    assert mof.cavity.show == False
+    bpy.context.scene.Bcavity.minCave = 3.0
+    assert np.isclose(mof.cavity.minCave, 3.0)
 
 if __name__ == "__main__":
     test_cavity()

--- a/tests/test_crystal_shape.py
+++ b/tests/test_crystal_shape.py
@@ -60,6 +60,16 @@ def test_settings():
     au.crystal_shape.settings.remove((1, 1, 1))
     assert au.crystal_shape.settings.find((1, 1, 1)) is None
 
+def test_gui():
+    """crystal shape panel"""
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(formula="Au", cubic=True)
+    au = Batoms('Au')
+    au.obj.select_set(True)
+    assert bpy.context.scene.Bcrystalshape.show == True
+    bpy.context.scene.Bcrystalshape.show = False
+    assert au.crystal_shape.show == False
 
 def test_crystalshape_uilist():
     """crystalshape panel"""

--- a/tests/test_gui_cell.py
+++ b/tests/test_gui_cell.py
@@ -1,0 +1,19 @@
+import bpy
+from batoms import Batoms
+from batoms.bio.bio import read
+import pytest
+
+
+def test_cell():
+    """Cell panel"""
+    from batoms.batoms import Batoms
+    import numpy as np
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.molecule_add()
+    ch4 = Batoms('CH4')
+    ch4.obj.select_set(True)
+    # model_style
+    assert np.isclose(bpy.context.scene.batoms.cell.cell_a0, 0)
+    bpy.context.scene.batoms.cell.cell_a0 = 3
+    assert np.isclose(bpy.context.scene.batoms.cell.cell_a0, 3)
+    assert np.isclose(ch4.cell[0, 0], 3)

--- a/tests/test_lattice_plane.py
+++ b/tests/test_lattice_plane.py
@@ -60,8 +60,18 @@ def test_lattice_plane_ops():
     print(au.lattice_plane.settings)
     bpy.ops.plane.lattice_plane_draw()
 
+def test_gui():
+    """latticeplane panel"""
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(formula="Au", cubic=True)
+    au = Batoms('Au')
+    au.obj.select_set(True)
+    assert bpy.context.scene.Blatticeplane.show == True
+    bpy.context.scene.Blatticeplane.show = False
+    assert au.lattice_plane.show == False
 
-def test_latticeplane_uilist():
+def test_gui_uilist():
     """latticeplane panel"""
     from batoms.batoms import Batoms
     bpy.ops.batoms.delete()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,69 @@
+import bpy
+import pytest
+from ase.build import bulk
+from batoms import Batoms
+from batoms.bio.bio import read
+import numpy as np
+import os
+try:
+    from _common_helpers import has_display, set_cycles_res
+
+    use_cycles = not has_display()
+except ImportError:
+    use_cycles = False
+
+extras = dict(engine="cycles") if use_cycles else {}
+
+skip_test = bool(os.environ.get("NOTEST_CUBE", 0))
+
+
+def test_template():
+    bpy.ops.batoms.delete()
+    au = bulk("Au", cubic=True)
+    au = Batoms("au", from_ase=au)
+    au.template.settings['test'] = {"prop1": 1.1}
+    print(au.template.settings)
+    au.template.draw()
+
+
+def test_template_ops():
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(formula="Au")
+    au = Batoms('Au')
+    bpy.context.view_layer.objects.active = au.obj
+    bpy.ops.template.template_add(name='test')
+    au.template.settings['test'].scale = 3.0
+    assert len(au.template.settings) == 1
+    bpy.ops.template.template_draw()
+    bpy.ops.template.template_remove(name="test")
+    assert len(au.template.settings) == 0
+    print(au.template.settings)
+    bpy.ops.template.template_draw()
+
+def test_gui():
+    """latticeplane panel"""
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(formula="Au", cubic=True)
+    au = Batoms('Au')
+    au.obj.select_set(True)
+    assert bpy.context.scene.Btemplate.show == True
+    bpy.context.scene.Btemplate.show = False
+    assert au.template.show == False
+
+def test_gui_uilist():
+    """latticeplane panel"""
+    from batoms.batoms import Batoms
+    bpy.ops.batoms.delete()
+    bpy.ops.batoms.bulk_add(formula="Au", cubic=True)
+    au = Batoms('Au')
+    au.obj.select_set(True)
+    assert au.coll.Btemplate.ui_list_index==0
+    bpy.ops.template.template_add(name='test1')
+    bpy.ops.template.template_add(name='test2')
+    assert au.coll.Btemplate.ui_list_index==1
+
+
+if __name__ == "__main__":
+    test_template()
+    print("\n Template: All pass! \n")


### PR DESCRIPTION
#173 

Now the panel for the plugin has two parts:
- The main panel show parameters which control overall properties
- An `Item settings` sub-panel that sets the properties of each item. 

Here is an example for the Cavity panel:
<img width=200 src="https://user-images.githubusercontent.com/11457659/178161762-05b8d977-3e4d-4cfc-b558-988284deec91.png" />

