### PR TITLE
support repeating of volumetric data

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -943,8 +943,8 @@ class Batoms(BaseCollection, ObjectGN):
         # self.set_frames(frames_new)
         self.cell.repeat(m)
         self.update_gn_cell()
-        # if self.volumetric_data is not None:
-        # self.volumetric_data = np.tile(self.volumetric_data, m)
+        if self.volumetric_data is not None:
+            self._volumetric_data *= m
         self.species.update_geometry_node()
         if self._boundary is not None:
             self.boundary.update()

--- a/tests/test_volumetric_data.py
+++ b/tests/test_volumetric_data.py
@@ -82,3 +82,13 @@ def test_ops_create():
         operator='Minus')
     assert h2o.coll.batoms.ui_list_index_volumetric_data == 2
     assert np.isclose(h2o.volumetric_data['diff'], 0).all()
+
+def test_repeat():
+    from batoms.bio.bio import read
+    bpy.ops.batoms.delete()
+    h2o = read("../tests/datas/h2o-homo.cube")
+    shape = h2o.volumetric_data["h2o_homo"].shape
+    M = [2, 2, 1]
+    h2o._volumetric_data *= M
+    new_shape = h2o.volumetric_data["h2o_homo"].shape
+    assert list(new_shape) == [shape[i]*M[i] for i in range(3)]


### PR DESCRIPTION
Repeat the volumetric data when repeating the batoms object.
Here is an H2O molecule with HOMO orbital.

<img width=200 src=https://github.com/beautiful-atoms/beautiful-atoms/assets/11457659/c1720653-196f-495d-8b1a-6b7dcfadf4cb>

Repeat the batoms:
```python
h2o *= [2, 2, 1]
h2o_homo.isosurface.draw()
```

<img width=400 src=https://github.com/beautiful-atoms/beautiful-atoms/assets/11457659/676c694e-3dff-4800-96f7-58c2c5df6b95)>


