### PR TITLE
color atoms by attributes

### DIFF
--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -353,8 +353,7 @@ class Batoms(BaseCollection, ObjectGN):
                                             'SetMaterial_%s_%s' % (
                                                 self.label, spname),
                                             'GeometryNodeSetMaterial')
-        mat_name = '%s_%s_%s' % (self.label, spname, spname)
-        SetMaterial.inputs[2].default_value = bpy.data.materials[mat_name]
+        SetMaterial.inputs[2].default_value = instancer.data.materials[0]
         #
         gn.node_group.links.new(SetPosition.outputs['Geometry'],
                                 InstanceOnPoint.inputs['Points'])

--- a/batoms/batoms.py
+++ b/batoms/batoms.py
@@ -348,6 +348,13 @@ class Batoms(BaseCollection, ObjectGN):
                                      'BooleanMath_%s_%s_1' % (
                                          self.label, spname),
                                      'FunctionNodeBooleanMath')
+        # set materials
+        SetMaterial = get_nodes_by_name(gn.node_group.nodes,
+                                            'SetMaterial_%s_%s' % (
+                                                self.label, spname),
+                                            'GeometryNodeSetMaterial')
+        mat_name = '%s_%s_%s' % (self.label, spname, spname)
+        SetMaterial.inputs[2].default_value = bpy.data.materials[mat_name]
         #
         gn.node_group.links.new(SetPosition.outputs['Geometry'],
                                 InstanceOnPoint.inputs['Points'])
@@ -362,6 +369,8 @@ class Batoms(BaseCollection, ObjectGN):
         gn.node_group.links.new(ObjectInfo.outputs['Geometry'],
                                 InstanceOnPoint.inputs['Instance'])
         gn.node_group.links.new(InstanceOnPoint.outputs['Instances'],
+                                SetMaterial.inputs['Geometry'])
+        gn.node_group.links.new(SetMaterial.outputs['Geometry'],
                                 JoinGeometry.inputs['Geometry'])
 
     def check_batoms(self, label):

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -355,8 +355,9 @@ class Species(BaseObject):
         self.build_materials(material_style = material_style)
         self.assign_materials()
 
-    def color_by_attribute(self, attribute, colors=[(1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1)]):
+    def color_by_attribute(self, attribute, cmap="viridis"):
         """Color by attribute"""
+        import matplotlib.pyplot as plt
         node_tree = self.materials[self.main_element].node_tree
         if attribute in ["element"]:
             # remove the link
@@ -370,6 +371,8 @@ class Species(BaseObject):
             else:
                 color_ramp_node = node_tree.nodes.get('ColorRamp')
             node_tree.nodes['Attribute'].attribute_name = attribute
+            colormap = plt.get_cmap(cmap)
+            colors = colormap([0, 0.5, 1])
             color_ramp_node.color_ramp.elements[0].color = colors[0]
             color_ramp_node.color_ramp.elements[1].color = colors[1]
             color_ramp_node.color_ramp.elements[2].color = colors[2]
@@ -673,6 +676,6 @@ class Bspecies(Setting):
             data[name] = sp.as_dict()
         return data
 
-    def color_by_attribute(self, attribute, colors=[(1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1)]):
+    def color_by_attribute(self, attribute, cmap="viridis"):
         for _, sp in self.species.items():
-            sp.color_by_attribute(attribute, colors=colors)
+            sp.color_by_attribute(attribute, cmap=cmap)

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -155,6 +155,13 @@ class Species(BaseObject):
                                   node_inputs=node_inputs,
                                   material_style=material_style,
                                   backface_culling=True)
+            # add attribute and color ramp
+            Attrribute = mat.node_tree.nodes.new('ShaderNodeAttribute')
+            Attrribute.attribute_type = 'INSTANCER'
+            ValToRGB = mat.node_tree.nodes.new('ShaderNodeValToRGB')
+            mat.node_tree.links.new(Attrribute.outputs['Fac'],
+                                ValToRGB.inputs['Fac'])
+            
             mesh.materials.append(mat)
             self.parent.batoms.obj.data.materials.append(mat)
             i += 1
@@ -343,6 +350,18 @@ class Species(BaseObject):
         self.data.material_style = material_style
         self.build_materials(material_style = material_style)
         self.assign_materials()
+
+    def color_by_attribute(self, attribute, colors=[(0, 0, 1, 1), (1, 0, 0, 1)]):
+        """
+        """
+        node_tree = self.materials[self.main_element].node_tree
+        print("node: ", node_tree.nodes['Attribute'])
+        print("name: ", node_tree.nodes['Attribute'].attribute_name)
+        node_tree.nodes['Attribute'].attribute_name = attribute
+        node_tree.nodes['Color Ramp'].color_ramp.elements[0].color = colors[0]
+        node_tree.nodes['Color Ramp'].color_ramp.elements[1].color = colors[1]
+        node_tree.links.new(node_tree.nodes['Color Ramp'].outputs['Color'],
+                                node_tree.nodes['Principled BSDF'].inputs['Base Color'])
 
     @property
     def radius(self):

--- a/batoms/bspecies.py
+++ b/batoms/bspecies.py
@@ -165,7 +165,7 @@ class Species(BaseObject):
             ValToRGB.color_ramp.elements[2].color = (0, 0, 1, 1)
             mat.node_tree.links.new(Attrribute.outputs['Fac'],
                                 ValToRGB.inputs['Fac'])
-            
+
             mesh.materials.append(mat)
             self.parent.batoms.obj.data.materials.append(mat)
             i += 1
@@ -361,14 +361,19 @@ class Species(BaseObject):
         if attribute in ["element"]:
             # remove the link
             for link in node_tree.links:
-                if link.from_node.name == 'Color Ramp' and link.to_node.name == 'Principled BSDF':
+                if link.from_node.name in ['Color Ramp', 'ColorRamp'] and link.to_node.name == 'Principled BSDF':
                     node_tree.links.remove(link)
         else:
+            # Blender 3.6: 'Color Ramp', Blender 3.4: 'ColorRamp'
+            if node_tree.nodes.get('Color Ramp'):
+                color_ramp_node = node_tree.nodes.get('Color Ramp')
+            else:
+                color_ramp_node = node_tree.nodes.get('ColorRamp')
             node_tree.nodes['Attribute'].attribute_name = attribute
-            node_tree.nodes['Color Ramp'].color_ramp.elements[0].color = colors[0]
-            node_tree.nodes['Color Ramp'].color_ramp.elements[1].color = colors[1]
-            node_tree.nodes['Color Ramp'].color_ramp.elements[2].color = colors[2]
-            node_tree.links.new(node_tree.nodes['Color Ramp'].outputs['Color'],
+            color_ramp_node.color_ramp.elements[0].color = colors[0]
+            color_ramp_node.color_ramp.elements[1].color = colors[1]
+            color_ramp_node.color_ramp.elements[2].color = colors[2]
+            node_tree.links.new(color_ramp_node.outputs['Color'],
                                     node_tree.nodes['Principled BSDF'].inputs['Base Color'])
 
     @property

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -99,7 +99,17 @@ def test_geometry_node_object():
     assert tio2.boundary.gnodes.node_group.nodes['ObjectInfo_tio2_Ti'].inputs['Object'].default_value is not None
     assert tio2.bond.search_bond.gnodes.node_group.nodes['ObjectInfo_tio2_Ti'].inputs['Object'].default_value is not None
 
-
+def test_color_by_attribute():
+    from ase.build import bulk
+    from batoms import Batoms
+    import numpy as np
+    au = bulk("Au", cubic=True)*[5, 5, 5]
+    au = Batoms(label = "au", from_ase = au)
+    z = au.positions[:, 2]
+    au.set_attributes({"z_coor": (z-np.min(z))/(np.max(z)-np.min(z)) })
+    au.species.color_by_attribute("z_coor")
+    assert au.species['Au'].materials['Au'].node_tree.nodes['Attribute'].attribute_name == "z_coor"
+    assert len(au.species['Au'].materials['Au'].node_tree.links) > 2
 
 if __name__ == "__main__":
     test_batoms_species()


### PR DESCRIPTION
Fix #46 
It is useful to color atoms by their attributes (e.g. charge, stress). This PR adds a `color_by_attribute` to the species. Here is a example to color atoms by their z coordinate:


```python
from ase.build import bulk
from batoms import Batoms
import numpy as np
au = bulk("Au", cubic=True)*[5, 5, 5]
au = Batoms(label = "au", from_ase = au)
# add z coordinate as a new attribute, normalized it to [0, 1]
z = au.positions[:, 2]
au.set_attributes({"z_coor": (z-np.min(z))/(np.max(z)-np.min(z)) })
# color atoms by their z coordinate
au.species.color_by_attribute("z_coor")
au.get_image(viewport = [1, 0, 0], output = "color_by_z_coordinate.png")
```
<img width=300 src="https://github.com/beautiful-atoms/beautiful-atoms/assets/11457659/56ee2d17-811f-49e2-8f6a-caab6eee22b6" >

