### PR TITLE
Update blender version and various in CI

### DIFF
--- a/.github/workflows/batoms_plugin_test.yaml
+++ b/.github/workflows/batoms_plugin_test.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ["3.4"]
+        blender-version: ["3.6"]
     container:
       # env is not
       image: ghcr.io/beautiful-atoms/blender-env:blender${{ matrix.blender-version }}
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        blender-version: ["3.4"]
+        blender-version: ["3.6"]
     container:
       image: ghcr.io/beautiful-atoms/beautiful-atoms:blender${{ matrix.blender-version }}
       options: --user root

--- a/.github/workflows/build_blender_env_image.yml
+++ b/.github/workflows/build_blender_env_image.yml
@@ -4,7 +4,7 @@ env:
   DOCKERHUB_USERNAME: luciusm
   IMAGE_NAME: blender-env
   TEST_TAG: blender-env:tests
-  LATEST_VERSION: "3.4"
+  LATEST_VERSION: "3.6"
 
 on:
   push:
@@ -22,7 +22,8 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ["3.0", "3.1", "3.2", "3.4"]
+        # Blender 3.3 seems to break
+        blender-version: ["3.0", "3.1", "3.2", "3.4", "3.5", "3.6"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_main_image.yml
+++ b/.github/workflows/build_main_image.yml
@@ -5,7 +5,7 @@ env:
   BASE_IMAGE_NAME: blender-env
   IMAGE_NAME: beautiful-atoms
   TEST_TAG: beautiful-atoms:tests
-  LATEST_VERSION: "3.4"
+  LATEST_VERSION: "3.6"
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         # Manually change these to match the blender image versions
-        blender-version: ["3.0", "3.1", "3.2", "3.4"]
+        blender-version: ["3.0", "3.1", "3.2", "3.4", "3.5", "3.6"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -31,7 +31,8 @@ jobs:
         with:
           activate-environment: batoms
           python-version: "3.10"
-          mamba-version: "*"
+          #mamba-version: "*"
+          miniforge-variant: Mambaforge # Fix according to https://github.com/nextstrain/cli/commit/4a764976519ca5c540c745463548a9d883eae079
           channels: conda-forge,defaults
       - name: Update libstdc++ and
         run: |
@@ -68,7 +69,8 @@ jobs:
         with:
           activate-environment: batoms
           python-version: "3.10"
-          mamba-version: "*"
+          #mamba-version: "*"
+          miniforge-variant: Mambaforge # Fix according to https://github.com/nextstrain/cli/commit/4a764976519ca5c540c745463548a9d883eae079
           channels: conda-forge,defaults
       - name: Update libstdc++ and
         run: |
@@ -138,7 +140,8 @@ jobs:
         with:
           activate-environment: batoms
           python-version: "3.10"
-          mamba-version: "*"
+          #mamba-version: "*"
+          miniforge-variant: Mambaforge # Fix according to https://github.com/nextstrain/cli/commit/4a764976519ca5c540c745463548a9d883eae079
           channels: conda-forge,defaults
       - name: Download portable blender
         run: |

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -157,6 +157,9 @@ jobs:
           echo "BLENDER_ROOT=$HOME/Applications/Blender.app/Contents/Resources/${MAJ_VER}" >> $GITHUB_ENV
           chmod -R u+x $HOME/Applications/Blender.app
           # ls "$HOME/Library/Application Support/Blender/${MAJ_VER}/config/"
+      # Just debugger session
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
       - name: Run installation and uninstallation script
         run: |
           echo Currently install in $(pwd)

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  BLENDER_DOWN_URL: "https://mirror.clarkson.edu/blender/release"
+  BLENDER_DOWN_URL: "https://mirrors.ocf.berkeley.edu/blender/release"
 
 jobs:
   unittest-linux:

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         # Somehow the macos installers are throwing segfault, could we check?
-        blender_ver: ["3.4.2"]
+        blender_ver: ["3.4.1"]
         
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -133,7 +133,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        blender_ver: ["3.6.4"]
+        blender_ver: ["3.6.2"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -158,6 +158,10 @@ jobs:
           chmod -R u+x $HOME/Applications/Blender.app
           # ls "$HOME/Library/Application Support/Blender/${MAJ_VER}/config/"
       # Just debugger session
+      - name: try call macos blender
+        run: |
+          /Users/runner/Applications/Blender.app/Contents/MacOS/Blender -b || true
+          find /var/folders -name blender.crash.txt -exec cat {} \;
       - name: Setup upterm session
         uses: lhotari/action-upterm@v1
       - name: Run installation and uninstallation script

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -133,7 +133,9 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        blender_ver: ["3.6.2"]
+        # Somehow the macos installers are throwing segfault, could we check?
+        blender_ver: ["3.4.2"]
+        
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -161,9 +163,9 @@ jobs:
       - name: try call macos blender
         run: |
           /Users/runner/Applications/Blender.app/Contents/MacOS/Blender -b || true
-          find /var/folders -name blender.crash.txt -exec cat {} \;
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+          find /var/folders -name blender.crash.txt -exec cat {} \; || true
+      # - name: Setup upterm session
+      #   uses: lhotari/action-upterm@v1
       - name: Run installation and uninstallation script
         run: |
           echo Currently install in $(pwd)

--- a/.github/workflows/test_install_script.yaml
+++ b/.github/workflows/test_install_script.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # For future tests we will only over 3 of the latest versions
-        blender_ver: ["3.4.1"]
+        blender_ver: ["3.6.4"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         # For future tests we will only over 3 of the latest versions
-        blender_ver: ["3.4.1"]
+        blender_ver: ["3.6.4"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -133,7 +133,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        blender_ver: ["3.4.1"]
+        blender_ver: ["3.6.4"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
@@ -197,7 +197,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        blender_ver: ["3.4.1"]
+        blender_ver: ["3.6.4"]
     steps:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2

--- a/Dockerfiles/Dockerfile.env
+++ b/Dockerfiles/Dockerfile.env
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
 #     apt-get remove -y software-properties-common &&\
 #     apt-get clean autoclean &&\
 #     apt-get autoremove --yes &&\
-/#     rm -rf /var/lib/{apt,dpkg,cache,log}/
+#     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Use automatic parser script to download blender bin and python source
 WORKDIR /tmp

--- a/Dockerfiles/Dockerfile.env
+++ b/Dockerfiles/Dockerfile.env
@@ -2,7 +2,7 @@
 # Dockerfile adapted from https://github.com/nytimes/rd-blender-docker
 # To build the Docker image, create the build from root directory:
 # docker build --build-arg BLENDER_VERSION=3.0 . -f Dockerfiles/Dockerfile.base_3.0 -t <image_name>:blender3.0
-FROM nvidia/cudagl:10.1-base-ubuntu18.04
+FROM nvidia/cudagl:11.4.1-runtime-ubuntu20.04
 
 ARG BLENDER_VERSION=3.4
 
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y \
 #     apt-get remove -y software-properties-common &&\
 #     apt-get clean autoclean &&\
 #     apt-get autoremove --yes &&\
-#     rm -rf /var/lib/{apt,dpkg,cache,log}/
+/#     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 # Use automatic parser script to download blender bin and python source
 WORKDIR /tmp

--- a/Dockerfiles/bl_release_parser.py
+++ b/Dockerfiles/bl_release_parser.py
@@ -53,7 +53,7 @@ def get_default_bl_py_version(blender_root):
 def extract_python_source(blender_root, python_version):
     short_version = ".".join(python_version.split(".")[:2])
     url = f"https://www.python.org/ftp/python/{python_version}/Python-{python_version}.tgz"
-    commands = f"wget {url} && tar -xzf Python-*.tgz && cp -r Python-*/Include/* {blender_root}/python/include/python{short_version}/ && rm -rf Python-*"
+    commands = f"wget {url} && tar -xzf Python-*.tgz && mkdir -p {blender_root}/python/include/python{short_version} && cp -r Python-*/Include/* {blender_root}/python/include/python{short_version}/ && rm -rf Python-*"
     proc = run(commands, shell=True)
     if proc.returncode != 0:
         raise RuntimeError("Error extracting python source")

--- a/install.py
+++ b/install.py
@@ -62,7 +62,7 @@ FACTORY_PIP_PACKAGES = [
     "zstandard",
 ]
 
-ALLOWED_BLENDER_VERSIONS = ["3.4", "3.5"]
+ALLOWED_BLENDER_VERSIONS = ["3.4", "3.5", "3.6"]
 DEPRECATED_BLENDER_VERSIONS = ["3.0", "3.1", "3.2"]
 
 PY_PATH = "python"

--- a/install.py
+++ b/install.py
@@ -424,11 +424,13 @@ def _get_default_locations(os_name):
             )
         )
     matches = []
+    true_search_locations = []
     for l in default_locations[os_name]:
         for version in ALLOWED_BLENDER_VERSIONS:
             true_location = Path(
                 expandvars(expanduser(l.format(version=version)))
             ).absolute()
+            true_search_locations.append(true_location)
             if true_location.is_dir():
                 matches.append(true_location)
     # Multiple blender installation may occur on macos
@@ -445,7 +447,8 @@ def _get_default_locations(os_name):
     if match is None:
         raise FileNotFoundError(
             (
-                f"Cannot find Blender>=3.4 in default installation locations. "
+                f"Cannot find Blender>=3.4 in default installation locations: \n"
+                f"{true_search_locations} \n"
                 "Please specify the full path to the blender installation location."
             )
         )


### PR DESCRIPTION
- Update blender version in docker image / installer / plugin tests to 3.6
- Fix bug with mamba installer
- Fix a few minor bugs in version fetching scripts
- For now Blender 3.6+ still throw segfault on github's CI macos, but working on a local machine. Will look into the issue later