### PR TITLE
Add materials property to Bonds and Isosurface

### DIFF
--- a/batoms/bond/setting.py
+++ b/batoms/bond/setting.py
@@ -509,6 +509,20 @@ class BondSettings(Setting):
                             ] = mat
         return materials
 
+    def set_material(self, sp, node_inputs=None):
+        if isinstance(sp, tuple):
+            sp = tuple2string(sp)
+        if isinstance(sp, str):
+            sp = self[sp].as_dict()
+
+        self.build_materials(sp, sp["order"], sp["style"], node_inputs)
+        self.assign_materials(sp, sp["order"], sp["style"])
+
+    @materials.setter
+    def materials(self, node_inputs):
+        for sp in self.keys():
+            self.set_material(sp, node_inputs)
+
     def __setitem__(self, index, setdict):
         """
         Set properties

--- a/batoms/plugins/isosurface/isosurface.py
+++ b/batoms/plugins/isosurface/isosurface.py
@@ -101,6 +101,31 @@ class Isosurface(BaseObject):
         )
         return mat
 
+    @property
+    def materials(self):
+        materials = {}
+        for key in self.settings.bpy_setting.keys():
+            name = f'{self.label}_isosurface_{key}'
+            if name in bpy.data.materials:
+                materials[key] = bpy.data.materials.get(name)
+        return materials
+
+    @materials.setter
+    def materials(self, node_inputs):
+        for key in self.settings.bpy_setting.keys():
+            name = f'{self.label}_isosurface_{key}'
+
+            # Remove the old material
+            obj = bpy.data.objects.get(name)
+            obj.data.materials.clear()
+
+            # Create the material
+            color = self.settings[key].color
+            mat = self.build_materials(name, color, node_inputs=node_inputs)
+
+            # Assign the material to the isosurface object
+            obj.data.materials.append(mat)
+
     def draw(self, isosurface_name="ALL"):
         """Draw isosurface."""
         from batoms.draw import draw_surface_from_vertices


### PR DESCRIPTION
This PR starts to address #211 by making `materials` a settable property of the `Bond` and `Isosurface` classes.

The syntax is:
```
ba.bond.settings.materials = {'Metallic': 0.0, 'Roughness': 0.8}
```
for `Bond` and
```
ba.isosurface.materials = {'Metallic': 0.0, 'Roughness': 0.8}
```
for `Isosurface`.
If you only want to set the material of a particular bond type you can use `set_material()`.

To do
----
- [ ] add proper error message if `atoms.isosurface.draw()` has not been called before `ba.isosurface.materials = ...`
- [ ] make `set_material` for bonds more flexible (i.e. allow user to set for a particular order, etc)
- [ ] explore options for `ba.bond.materials` rather than `ba.bond.settings.materials`